### PR TITLE
Documentation, `TypeAlias` start, annotation inference

### DIFF
--- a/advanced-record-utils-annotations/pom.xml
+++ b/advanced-record-utils-annotations/pom.xml
@@ -13,6 +13,10 @@
 
     <name>Advanced Record Utils - Annotations</name>
     <description>Annotations intended to be used by the Advanced Record Utils processor</description>
+    <url>https://github.com/cbarlin/advanced-record-utils</url>
+    <scm>
+        <url>https://github.com/cbarlin/advanced-record-utils</url>
+    </scm>
 
     <dependencies>
         <!-- Required dependencies -->

--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/TypeAlias.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/TypeAlias.java
@@ -1,10 +1,17 @@
 package io.github.cbarlin.aru.annotations;
 
+import org.jspecify.annotations.NonNull;
+
 /**
  * An alias for another kind. Useful for situations in which you wish
  *   to manage a variety of e.g. numeric IDs and use Java's type system to
  *   not get them confused.
  */
 public interface TypeAlias<T> {
+    /**
+     * The value of this alias. Cannot be null.
+     * @return The value held by the alias.
+     */
+    @NonNull
     T value();
 }

--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/aliases/IntegerAlias.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/aliases/IntegerAlias.java
@@ -1,0 +1,16 @@
+package io.github.cbarlin.aru.annotations.aliases;
+
+import org.jspecify.annotations.NonNull;
+
+import io.github.cbarlin.aru.annotations.TypeAlias;
+
+public interface IntegerAlias extends TypeAlias<Integer>, Comparable<IntegerAlias> {
+
+    @Override
+    @NonNull Integer value();
+
+    @Override
+    default int compareTo(IntegerAlias o) {
+        return value().compareTo(o.value());
+    }
+}

--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/aliases/LongAlias.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/aliases/LongAlias.java
@@ -1,0 +1,16 @@
+package io.github.cbarlin.aru.annotations.aliases;
+
+import org.jspecify.annotations.NonNull;
+
+import io.github.cbarlin.aru.annotations.TypeAlias;
+
+public interface LongAlias extends TypeAlias<Long>, Comparable<LongAlias> {
+
+    @Override
+    @NonNull Long value();
+
+    @Override
+    default int compareTo(LongAlias o) {
+        return value().compareTo(o.value());
+    }
+}

--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/aliases/StringAlias.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/aliases/StringAlias.java
@@ -1,0 +1,34 @@
+package io.github.cbarlin.aru.annotations.aliases;
+
+import org.jspecify.annotations.NonNull;
+
+import io.github.cbarlin.aru.annotations.TypeAlias;
+
+/**
+ * A helper interface for making {@link TypeAlias} for {@link String}
+ */
+public interface StringAlias extends TypeAlias<String>, CharSequence, Comparable<StringAlias> {
+
+    @Override
+    @NonNull String value();
+
+    @Override
+    default int length() {
+        return value().length();
+    }
+
+    @Override
+    default char charAt(int index) {
+        return value().charAt(index);
+    }
+
+    @Override
+    default CharSequence subSequence(int start, int end) {
+        return value().subSequence(start, end);
+    }
+
+    @Override
+    default int compareTo(StringAlias o) {
+        return value().compareTo(o.value());
+    }
+}

--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/aliases/UuidAlias.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/aliases/UuidAlias.java
@@ -1,0 +1,18 @@
+package io.github.cbarlin.aru.annotations.aliases;
+
+import java.util.UUID;
+
+import org.jspecify.annotations.NonNull;
+
+import io.github.cbarlin.aru.annotations.TypeAlias;
+
+public interface UuidAlias extends TypeAlias<UUID>, Comparable<UuidAlias> {
+
+    @Override
+    @NonNull UUID value();
+
+    @Override
+    default int compareTo(UuidAlias o) {
+        return value().compareTo(o.value());
+    }
+}

--- a/advanced-record-utils-annotations/src/main/java/module-info.java
+++ b/advanced-record-utils-annotations/src/main/java/module-info.java
@@ -1,5 +1,10 @@
 import org.jspecify.annotations.NullMarked;
 
+/**
+ * Dependency for users.
+ * <p>
+ * Basic useage is available at https://github.com/cbarlin/advanced-record-utils
+ */
 @NullMarked
 module io.github.cbarlin.aru.annotations {
 

--- a/advanced-record-utils-annotations/src/main/java/module-info.java
+++ b/advanced-record-utils-annotations/src/main/java/module-info.java
@@ -9,6 +9,7 @@ import org.jspecify.annotations.NullMarked;
 module io.github.cbarlin.aru.annotations {
 
     exports io.github.cbarlin.aru.annotations;
+    exports io.github.cbarlin.aru.annotations.aliases;
 
     requires java.base;
     requires static org.jspecify;

--- a/advanced-record-utils-processor/pom.xml
+++ b/advanced-record-utils-processor/pom.xml
@@ -8,12 +8,15 @@
           <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <groupId>io.github.cbarlin</groupId>
     <artifactId>advanced-record-utils-processor</artifactId>
+    <url>https://github.com/cbarlin/advanced-record-utils</url>
     <packaging>jar</packaging>
 
     <name>Advanced Record Utils - Processor</name>
     <description>The processor to generate Advanced Record Utils</description>
+    <scm>
+        <url>https://github.com/cbarlin/advanced-record-utils</url>
+    </scm>
 
     <dependencies>
         <dependency>

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
@@ -15,7 +15,6 @@ import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import io.github.cbarlin.aru.core.ClaimableOperation;
 import io.github.cbarlin.aru.core.CommonsConstants;
-
 import io.micronaut.sourcegen.javapoet.ClassName;
 
 public enum Constants {
@@ -60,6 +59,7 @@ public enum Constants {
     
     public enum Names {
         ;
+        private static final String XML_ANNOTATIONS = "jakarta.xml.bind.annotation";
         public static final ClassName AVAJE_CONSTRAINT_VIOLATION = ClassName.get("io.avaje.validation", "ConstraintViolationException");
         public static final ClassName AVAJE_JSONB_IMPORT = ClassName.get("io.avaje.jsonb", "Json", "Import");
         public static final ClassName AVAJE_VALIDATOR = ClassName.get("io.avaje.validation", "Validator");
@@ -81,10 +81,15 @@ public enum Constants {
         public static final ClassName UNARY_OPERATOR = ClassName.get(UnaryOperator.class);
         public static final ClassName UUID = ClassName.get(java.util.UUID.class);
         public static final ClassName VALIDATE = ClassName.get("org.apache.commons.lang3", "Validate");
-        public static final ClassName XML_ELEMENT_DEFAULT = ClassName.get("jakarta.xml.bind.annotation", "XmlElement", "DEFAULT");
+        public static final ClassName XML_ATTRIBUTE = ClassName.get(XML_ANNOTATIONS, "XmlAttribute");
+        public static final ClassName XML_ELEMENT = ClassName.get(XML_ANNOTATIONS, "XmlElement");
+        public static final ClassName XML_ELEMENT_DEFAULT = XML_ELEMENT.nestedClass("DEFAULT");
+        public static final ClassName XML_ELEMENT_WRAPPER = ClassName.get(XML_ANNOTATIONS, "XmlElementWrapper");
+        public static final ClassName XML_ELEMENTS = ClassName.get(XML_ANNOTATIONS, "XmlElements");
         public static final ClassName XML_NAMESPACE_CONTEXT = ClassName.get("javax.xml.namespace", "NamespaceContext");
         public static final ClassName XML_STREAM_EXCEPTION = ClassName.get("javax.xml.stream", "XMLStreamException");
         public static final ClassName XML_STREAM_WRITER = ClassName.get("javax.xml.stream", "XMLStreamWriter");
+        public static final ClassName XML_TRANSIENT = ClassName.get(XML_ANNOTATIONS, "XmlTransient");
         public static final ClassName ZONE_ID = ClassName.get(ZoneId.class);
         public static final ClassName ZONE_OFFSET = ClassName.get(ZoneOffset.class);
         public static final ClassName ZONED_DATE_TIME = ClassName.get(ZonedDateTime.class);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/inferencer/XmlAnnotationMapper.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/inferencer/XmlAnnotationMapper.java
@@ -1,0 +1,43 @@
+package io.github.cbarlin.aru.impl.inferencer;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.XML_ATTRIBUTE;
+
+import java.util.Optional;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.RecordComponentElement;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.inference.ClassNameToPrismAdaptor;
+import io.github.cbarlin.aru.prism.prison.XmlAttributePrism;
+import io.micronaut.sourcegen.javapoet.ClassName;
+
+@ServiceProvider
+public class XmlAnnotationMapper implements ClassNameToPrismAdaptor<XmlAttributePrism> {
+
+    @Override
+    public ClassName supportedAnnotationClassName() {
+        return XML_ATTRIBUTE;
+    }
+
+    @Override
+    public Class<XmlAttributePrism> prismClass() {
+        return XmlAttributePrism.class;
+    }
+
+    @Override
+    public Optional<XmlAttributePrism> optionalInstanceOf(AnnotationMirror typeMirror) {
+        return XmlAttributePrism.getOptional(typeMirror);
+    }
+
+    @Override
+    public Optional<XmlAttributePrism> optionalInstanceOn(Element element) {
+        if (element instanceof RecordComponentElement rce) {
+            return XmlAttributePrism.getOptionalOn(rce.getAccessor())
+                .or(() -> XmlAttributePrism.getOptionalOn(rce));
+        }
+        return XmlAttributePrism.getOptionalOn(element);
+    }
+
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/inferencer/XmlElementMapper.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/inferencer/XmlElementMapper.java
@@ -1,0 +1,103 @@
+package io.github.cbarlin.aru.impl.inferencer;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.XML_ELEMENT;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.RecordComponentElement;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.AdvancedRecordUtilsPrism;
+import io.github.cbarlin.aru.core.UtilsProcessingContext;
+import io.github.cbarlin.aru.core.inference.AnnotationInferencer;
+import io.github.cbarlin.aru.core.inference.ClassNameToPrismAdaptor;
+import io.github.cbarlin.aru.core.mirrorhandlers.MapBasedAnnotationMirror;
+import io.github.cbarlin.aru.prism.prison.JsonBPrism;
+import io.github.cbarlin.aru.prism.prison.JsonBPropertyPrism;
+import io.github.cbarlin.aru.prism.prison.JsonPropertyPrism;
+import io.github.cbarlin.aru.prism.prison.XmlElementPrism;
+import io.micronaut.sourcegen.javapoet.ClassName;
+
+@ServiceProvider
+public class XmlElementMapper implements ClassNameToPrismAdaptor<XmlElementPrism>, AnnotationInferencer {
+
+    @Override
+    public ClassName supportedAnnotationClassName() {
+        return XML_ELEMENT;
+    }
+
+    @Override
+    public Class<XmlElementPrism> prismClass() {
+        return XmlElementPrism.class;
+    }
+
+    @Override
+    public Optional<XmlElementPrism> optionalInstanceOf(final AnnotationMirror typeMirror) {
+        return XmlElementPrism.getOptional(typeMirror);
+    }
+
+    @Override
+    public Optional<XmlElementPrism> optionalInstanceOn(final Element element) {
+        if (element instanceof final RecordComponentElement rce) {
+            return XmlElementPrism.getOptionalOn(rce.getAccessor())
+                .or(() -> XmlElementPrism.getOptionalOn(element));
+        }
+        return XmlElementPrism.getOptionalOn(element);
+    }
+
+    @Override
+    public int specificity() {
+        return 1;
+    }
+
+    @Override
+    public Optional<AnnotationMirror> inferAnnotationMirror(
+            final Element element, 
+            final UtilsProcessingContext processingContext,
+            final AdvancedRecordUtilsPrism prism
+    ) {
+        if (element instanceof RecordComponentElement rce) {
+            if (Boolean.TRUE.equals(prism.addJsonbImportAnnotation()) || JsonBPrism.isPresent(element.getEnclosingElement())) {
+                // Nice!
+                return JsonBPropertyPrism.getOptionalOn(rce)
+                    .or(() -> JsonBPropertyPrism.getOptionalOn(rce.getAccessor()))
+                    .map(propPrism -> new MapBasedAnnotationMirror(XML_ELEMENT, Map.of("name", propPrism.value())))
+                    .or(() -> Optional.ofNullable(new MapBasedAnnotationMirror(XML_ELEMENT)))
+                    .map(AnnotationMirror.class::cast);
+            } else if (JsonPropertyPrism.isPresent(element) || JsonPropertyPrism.isPresent(rce.getAccessor())) {
+                final var vals = JsonPropertyPrism.getOptionalOn(rce.getAccessor())
+                    .or(() -> JsonPropertyPrism.getOptionalOn(rce))
+                    .map(XmlElementMapper::extractJacksonProperty);
+                return Optional.of(new MapBasedAnnotationMirror(XML_ELEMENT, vals));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Map<String, Object> extractJacksonProperty(JsonPropertyPrism propPrism) {
+        final Map<String, Object> vs = new HashMap<>();
+
+        if (StringUtils.isNotBlank(propPrism.value())) {
+            vs.put("name", propPrism.value());
+        }
+        if (StringUtils.isNotBlank(propPrism.namespace())) {
+            vs.put("namespace", propPrism.namespace());
+        }
+        if (StringUtils.isNotBlank(propPrism.defaultValue())) {
+            vs.put("defaultValue", propPrism.defaultValue());
+        }
+        if (Objects.nonNull(propPrism.required())) {
+            vs.put("required", propPrism.required());
+        }
+
+        return vs;
+    }
+
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/inferencer/XmlElementWrapper.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/inferencer/XmlElementWrapper.java
@@ -1,0 +1,43 @@
+package io.github.cbarlin.aru.impl.inferencer;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.XML_ELEMENT_WRAPPER;
+
+import java.util.Optional;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.RecordComponentElement;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.inference.ClassNameToPrismAdaptor;
+import io.github.cbarlin.aru.prism.prison.XmlElementWrapperPrism;
+import io.micronaut.sourcegen.javapoet.ClassName;
+
+@ServiceProvider
+public class XmlElementWrapper implements ClassNameToPrismAdaptor<XmlElementWrapperPrism> {
+
+    @Override
+    public ClassName supportedAnnotationClassName() {
+        return XML_ELEMENT_WRAPPER;
+    }
+
+    @Override
+    public Class<XmlElementWrapperPrism> prismClass() {
+        return XmlElementWrapperPrism.class;
+    }
+
+    @Override
+    public Optional<XmlElementWrapperPrism> optionalInstanceOf(AnnotationMirror typeMirror) {
+        return XmlElementWrapperPrism.getOptional(typeMirror);
+    }
+
+    @Override
+    public Optional<XmlElementWrapperPrism> optionalInstanceOn(Element element) {
+        if (element instanceof RecordComponentElement rce) {
+            return XmlElementWrapperPrism.getOptionalOn(rce.getAccessor())
+                .or(() -> XmlElementWrapperPrism.getOptionalOn(rce));
+        }
+        return XmlElementWrapperPrism.getOptionalOn(element);
+    }
+
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/inferencer/XmlElementsMapper.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/inferencer/XmlElementsMapper.java
@@ -1,0 +1,68 @@
+package io.github.cbarlin.aru.impl.inferencer;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.XML_ELEMENT;
+import static io.github.cbarlin.aru.impl.Constants.Names.XML_ELEMENTS;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+
+import io.github.cbarlin.aru.core.AdvancedRecordUtilsPrism;
+import io.github.cbarlin.aru.core.UtilsProcessingContext;
+import io.github.cbarlin.aru.core.inference.AnnotationInferencer;
+import io.github.cbarlin.aru.core.inference.ClassNameToPrismAdaptor;
+import io.github.cbarlin.aru.core.mirrorhandlers.MapBasedAnnotationMirror;
+import io.github.cbarlin.aru.core.types.AnalysedInterface;
+import io.github.cbarlin.aru.prism.prison.XmlElementsPrism;
+import io.micronaut.sourcegen.javapoet.ClassName;
+
+public class XmlElementsMapper implements ClassNameToPrismAdaptor<XmlElementsPrism>, AnnotationInferencer {
+
+    @Override
+    public int specificity() {
+        return 0;
+    }
+
+    @Override
+    public Optional<AnnotationMirror> inferAnnotationMirror(
+            final Element element, 
+            final UtilsProcessingContext processingContext,
+            final AdvancedRecordUtilsPrism prism
+    ) {
+        if (element instanceof TypeElement te && processingContext.analysedType(te) instanceof AnalysedInterface ai) {
+            final List<AnnotationMirror> mirrors = List.of();
+            ai.implementingTypes()
+                .forEach(pt -> mirrors.add(new MapBasedAnnotationMirror(
+                    XML_ELEMENT,
+                    Map.of("type", pt.utilsClassName())
+                )));
+            return Optional.of(new MapBasedAnnotationMirror(XML_ELEMENTS, Map.of("value", mirrors)));
+        }
+        return Optional.empty();    
+    }
+
+    @Override
+    public ClassName supportedAnnotationClassName() {
+        return XML_ELEMENTS;
+    }
+
+    @Override
+    public Class<XmlElementsPrism> prismClass() {
+        return XmlElementsPrism.class;
+    }
+
+    @Override
+    public Optional<XmlElementsPrism> optionalInstanceOf(AnnotationMirror typeMirror) {
+        return XmlElementsPrism.getOptional(typeMirror);
+    }
+
+    @Override
+    public Optional<XmlElementsPrism> optionalInstanceOn(Element element) {
+        return XmlElementsPrism.getOptionalOn(element);
+    }
+
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/inferencer/XmlTransientMapper.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/inferencer/XmlTransientMapper.java
@@ -1,0 +1,73 @@
+package io.github.cbarlin.aru.impl.inferencer;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.XML_TRANSIENT;
+
+import java.util.Map;
+import java.util.Optional;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.RecordComponentElement;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.AdvancedRecordUtilsPrism;
+import io.github.cbarlin.aru.core.UtilsProcessingContext;
+import io.github.cbarlin.aru.core.inference.AnnotationInferencer;
+import io.github.cbarlin.aru.core.inference.ClassNameToPrismAdaptor;
+import io.github.cbarlin.aru.core.mirrorhandlers.MapBasedAnnotationMirror;
+import io.github.cbarlin.aru.prism.prison.JsonBIgnorePrism;
+import io.github.cbarlin.aru.prism.prison.JsonIgnorePrism;
+import io.github.cbarlin.aru.prism.prison.XmlTransientPrism;
+import io.micronaut.sourcegen.javapoet.ClassName;
+
+@ServiceProvider
+public class XmlTransientMapper implements ClassNameToPrismAdaptor<XmlTransientPrism>, AnnotationInferencer {
+
+    @Override
+    public ClassName supportedAnnotationClassName() {
+        return XML_TRANSIENT;
+    }
+
+    @Override
+    public Class<XmlTransientPrism> prismClass() {
+        return XmlTransientPrism.class;
+    }
+
+    @Override
+    public Optional<XmlTransientPrism> optionalInstanceOf(final AnnotationMirror typeMirror) {
+        return XmlTransientPrism.getOptional(typeMirror);
+    }
+
+    @Override
+    public Optional<XmlTransientPrism> optionalInstanceOn(final Element element) {
+        if (element instanceof final RecordComponentElement rce) {
+            return XmlTransientPrism.getOptionalOn(rce.getAccessor())
+                .or(() -> XmlTransientPrism.getOptionalOn(element));
+        }
+        return XmlTransientPrism.getOptionalOn(element);
+    }
+
+    @Override
+    public int specificity() {
+        return 1;
+    }
+
+    @Override
+    public Optional<AnnotationMirror> inferAnnotationMirror(
+            final Element element, 
+            final UtilsProcessingContext processingContext,
+            final AdvancedRecordUtilsPrism prism
+    ) {
+        if (element instanceof RecordComponentElement rce && hasIgnoreAnnotation(rce)) {
+            return Optional.of(new MapBasedAnnotationMirror(XML_TRANSIENT, Map.of()));
+        }
+        return Optional.empty();
+    }
+
+    private boolean hasIgnoreAnnotation(final RecordComponentElement rce) {
+        return JsonBIgnorePrism.isPresent(rce) ||
+            JsonBIgnorePrism.isPresent(rce.getAccessor()) ||
+            JsonIgnorePrism.isPresent(rce) ||
+            JsonIgnorePrism.isPresent(rce.getAccessor());
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/XmlVisitor.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/XmlVisitor.java
@@ -5,6 +5,10 @@ import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
 import static io.github.cbarlin.aru.impl.Constants.InternalReferenceNames.XML_DEFAULT_STRING;
 import static io.github.cbarlin.aru.impl.Constants.InternalReferenceNames.XML_UTILS_CLASS;
 import static io.github.cbarlin.aru.impl.Constants.Names.STRING;
+import static io.github.cbarlin.aru.impl.Constants.Names.XML_ATTRIBUTE;
+import static io.github.cbarlin.aru.impl.Constants.Names.XML_ELEMENT;
+import static io.github.cbarlin.aru.impl.Constants.Names.XML_ELEMENTS;
+import static io.github.cbarlin.aru.impl.Constants.Names.XML_ELEMENT_WRAPPER;
 import static io.github.cbarlin.aru.impl.Constants.Names.XML_STREAM_EXCEPTION;
 import static io.github.cbarlin.aru.impl.Constants.Names.XML_STREAM_WRITER;
 
@@ -30,6 +34,8 @@ import io.github.cbarlin.aru.impl.Constants.Claims;
 import io.github.cbarlin.aru.prism.prison.XmlAccessorOrderPrism;
 import io.github.cbarlin.aru.prism.prison.XmlAttributePrism;
 import io.github.cbarlin.aru.prism.prison.XmlElementPrism;
+import io.github.cbarlin.aru.prism.prison.XmlElementWrapperPrism;
+import io.github.cbarlin.aru.prism.prison.XmlElementsPrism;
 import io.github.cbarlin.aru.prism.prison.XmlRootElementPrism;
 import io.github.cbarlin.aru.prism.prison.XmlSchemaPrism;
 import io.github.cbarlin.aru.prism.prison.XmlTypePrism;
@@ -75,6 +81,22 @@ public abstract class XmlVisitor extends RecordVisitor {
         return false;
     }
 
+    protected Optional<XmlAttributePrism> xmlAttributePrism(final AnalysedComponent analysedComponent) {
+        return analysedComponent.findPrism(XML_ATTRIBUTE, XmlAttributePrism.class);
+    }
+
+    protected Optional<XmlElementPrism> xmlElementPrism(final AnalysedComponent analysedComponent) {
+        return analysedComponent.findPrism(XML_ELEMENT, XmlElementPrism.class);
+    }
+
+    protected Optional<XmlElementsPrism> xmlElementsPrism(final AnalysedComponent analysedComponent) {
+        return analysedComponent.findPrism(XML_ELEMENTS, XmlElementsPrism.class);
+    }
+
+    protected Optional<XmlElementWrapperPrism> xmlElementWrapperPrism(final AnalysedComponent analysedComponent) {
+        return analysedComponent.findPrism(XML_ELEMENT_WRAPPER, XmlElementWrapperPrism.class);
+    }
+
     protected abstract boolean innerIsApplicable(final AnalysedRecord analysedRecord);
 
     protected String attributeName(final AnalysedComponent analysedComponent, final XmlAttributePrism prism) {
@@ -84,7 +106,7 @@ public abstract class XmlVisitor extends RecordVisitor {
             .orElseGet(analysedComponent::name);
     }
 
-    protected Optional<String> namespaceName(final AnalysedComponent analysedComponent, final XmlAttributePrism prism) {
+    protected Optional<String> namespaceName(final XmlAttributePrism prism) {
         return Optional.ofNullable(prism.namespace())
             .filter(StringUtils::isNotBlank)
             .filter(Predicate.not(XML_DEFAULT_STRING::equals));
@@ -97,7 +119,7 @@ public abstract class XmlVisitor extends RecordVisitor {
             .orElseGet(analysedComponent::name);
     }
 
-    protected Optional<String> namespaceName(final AnalysedComponent analysedComponent, final XmlElementPrism prism) {
+    protected Optional<String> namespaceName(final XmlElementPrism prism) {
         return Optional.ofNullable(prism.namespace())
             .filter(StringUtils::isNotBlank)
             .filter(Predicate.not(XML_DEFAULT_STRING::equals));

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/WriteFallback.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/WriteFallback.java
@@ -98,7 +98,7 @@ public class WriteFallback extends XmlVisitor {
         final XmlElementPrism prism = XmlElementPrism.getInstanceOn(analysedComponent.element().getAccessor());
         boolean required = Boolean.TRUE.equals(prism.required());
         final String elementName = elementName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
         final Optional<String> defaultValue = defaultValue(prism);
 
         if (defaultValue.isPresent()) {
@@ -145,7 +145,7 @@ public class WriteFallback extends XmlVisitor {
         final XmlAttributePrism prism = XmlAttributePrism.getInstanceOn(analysedComponent.element().getAccessor());
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedBoolean.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedBoolean.java
@@ -31,7 +31,7 @@ public class WriteBoxedBoolean extends WriteXmlAttribute {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedChar.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedChar.java
@@ -31,7 +31,7 @@ public class WriteBoxedChar extends WriteXmlAttribute {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedDouble.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedDouble.java
@@ -31,7 +31,7 @@ public class WriteBoxedDouble extends WriteXmlAttribute {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedFloat.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedFloat.java
@@ -31,7 +31,7 @@ public class WriteBoxedFloat extends WriteXmlAttribute {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedInt.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedInt.java
@@ -31,7 +31,7 @@ public class WriteBoxedInt extends WriteXmlAttribute {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedLong.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedLong.java
@@ -31,7 +31,7 @@ public class WriteBoxedLong extends WriteXmlAttribute {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedShort.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedShort.java
@@ -31,7 +31,7 @@ public class WriteBoxedShort extends WriteXmlAttribute {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteCharSequence.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteCharSequence.java
@@ -31,7 +31,7 @@ public class WriteCharSequence extends XmlVisitor {
     @Override
     protected boolean visitComponentImpl(AnalysedComponent analysedComponent) {
         return Boolean.TRUE.equals(
-            XmlAttributePrism.getOptionalOn(analysedComponent.element().getAccessor())
+            xmlAttributePrism(analysedComponent)
                 .map(prism -> {
                     if (APContext.types().isSubtype(analysedComponent.componentType(), APContext.elements().getTypeElement(CharSequence.class.getCanonicalName()).asType())) {
                         visitAttributeComponent(analysedComponent, prism);
@@ -47,7 +47,7 @@ public class WriteCharSequence extends XmlVisitor {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent, CHAR_SEQUENCE);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteLocalDateTime.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteLocalDateTime.java
@@ -33,7 +33,7 @@ public class WriteLocalDateTime extends WriteXmlAttribute {
             .addJavadoc("Will convert to UTC by assuming that the system default time zone is the zone of the LocalDateTime");
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteOffsetDateTime.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteOffsetDateTime.java
@@ -31,7 +31,7 @@ public class WriteOffsetDateTime extends WriteXmlAttribute {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeBoolean.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeBoolean.java
@@ -27,7 +27,7 @@ public class WritePrimativeBoolean extends WriteXmlAttribute {
     void visitAttributeComponent(final AnalysedComponent analysedComponent, final XmlAttributePrism prism) {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
         namespaceName.ifPresentOrElse(
             namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, $T.valueOf(val))", namespace, attributeName, STRING),
             () -> methodBuilder.addStatement("output.writeAttribute($S, $T.valueOf(val))", attributeName, STRING)

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeChar.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeChar.java
@@ -27,7 +27,7 @@ public class WritePrimativeChar extends WriteXmlAttribute {
     void visitAttributeComponent(final AnalysedComponent analysedComponent, final XmlAttributePrism prism) {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
         namespaceName.ifPresentOrElse(
             namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, $T.valueOf(val))", namespace, attributeName, STRING),
             () -> methodBuilder.addStatement("output.writeAttribute($S, $T.valueOf(val))", attributeName, STRING)

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeDouble.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeDouble.java
@@ -27,7 +27,7 @@ public class WritePrimativeDouble extends WriteXmlAttribute {
     void visitAttributeComponent(final AnalysedComponent analysedComponent, final XmlAttributePrism prism) {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
         namespaceName.ifPresentOrElse(
             namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, $T.valueOf(val))", namespace, attributeName, STRING),
             () -> methodBuilder.addStatement("output.writeAttribute($S, $T.valueOf(val))", attributeName, STRING)

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeFloat.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeFloat.java
@@ -27,7 +27,7 @@ public class WritePrimativeFloat extends WriteXmlAttribute {
     void visitAttributeComponent(final AnalysedComponent analysedComponent, final XmlAttributePrism prism) {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
         namespaceName.ifPresentOrElse(
             namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, $T.valueOf(val))", namespace, attributeName, STRING),
             () -> methodBuilder.addStatement("output.writeAttribute($S, $T.valueOf(val))", attributeName, STRING)

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeInt.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeInt.java
@@ -27,7 +27,7 @@ public class WritePrimativeInt extends WriteXmlAttribute {
     void visitAttributeComponent(final AnalysedComponent analysedComponent, final XmlAttributePrism prism) {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         namespaceName.ifPresentOrElse(
             namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, $T.valueOf(val))", namespace, attributeName, STRING),

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeLong.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeLong.java
@@ -27,7 +27,7 @@ public class WritePrimativeLong extends WriteXmlAttribute {
     void visitAttributeComponent(final AnalysedComponent analysedComponent, final XmlAttributePrism prism) {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         namespaceName.ifPresentOrElse(
             namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, $T.valueOf(val))", namespace, attributeName, STRING),

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeShort.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimativeShort.java
@@ -27,7 +27,7 @@ public class WritePrimativeShort extends WriteXmlAttribute {
     void visitAttributeComponent(final AnalysedComponent analysedComponent, final XmlAttributePrism prism) {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         namespaceName.ifPresentOrElse(
             namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, $T.valueOf(val))", namespace, attributeName, STRING),

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteString.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteString.java
@@ -35,7 +35,7 @@ public class WriteString extends WriteXmlAttribute {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteUUID.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteUUID.java
@@ -29,7 +29,7 @@ public class WriteUUID extends WriteXmlAttribute {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteXmlAttribute.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteXmlAttribute.java
@@ -32,7 +32,7 @@ public abstract class WriteXmlAttribute extends XmlVisitor {
     @Override
     protected final boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
         return Boolean.TRUE.equals(
-            XmlAttributePrism.getOptionalOn(analysedComponent.element().getAccessor())
+            xmlAttributePrism(analysedComponent)
                 .map(prism -> {
                     if (supportedTypeName().equals(analysedComponent.typeName())) {
                         visitAttributeComponent(analysedComponent, prism);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteZonedDateTime.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteZonedDateTime.java
@@ -30,7 +30,7 @@ public class WriteZonedDateTime extends WriteXmlAttribute {
         final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
         final boolean required = Boolean.TRUE.equals(prism.required());
         final String attributeName = attributeName(analysedComponent, prism);
-        final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
 
         if (required) {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/collections/Branching.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/collections/Branching.java
@@ -15,6 +15,7 @@ import java.util.function.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
 
+import io.avaje.spi.ServiceProvider;
 import io.github.cbarlin.aru.core.APContext;
 import io.github.cbarlin.aru.core.artifacts.PreBuilt;
 import io.github.cbarlin.aru.core.impl.types.AnalysedOptionalComponent;
@@ -27,9 +28,6 @@ import io.github.cbarlin.aru.impl.Constants.Claims;
 import io.github.cbarlin.aru.impl.xml.XmlVisitor;
 import io.github.cbarlin.aru.prism.prison.XmlElementPrism;
 import io.github.cbarlin.aru.prism.prison.XmlElementWrapperPrism;
-import io.github.cbarlin.aru.prism.prison.XmlElementsPrism;
-
-import io.avaje.spi.ServiceProvider;
 import io.micronaut.sourcegen.javapoet.ClassName;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
 
@@ -66,7 +64,7 @@ public class Branching extends XmlVisitor {
             methodBuilder.beginControlFlow("if ($T.isNull(val))", OBJECTS)
                 .addStatement("return")
                 .endControlFlow();
-            final Optional<XmlElementWrapperPrism> wrapper = XmlElementWrapperPrism.getOptionalOn(analysedComponent.element().getAccessor());
+            final Optional<XmlElementWrapperPrism> wrapper = xmlElementWrapperPrism(analysedComponent);
             if (wrapper.isPresent()) {
                 writeWrapperElement(methodBuilder, wrapper.get());
             }
@@ -154,7 +152,7 @@ public class Branching extends XmlVisitor {
 
     private Map<ClassName, NameAndNamespace> extractNamedVersions(final AnalysedComponent analysedComponent, final AnalysedInterface other) {
         final Map<ClassName, NameAndNamespace> extracted = HashMap.newHashMap(other.implementingTypes().size());
-        XmlElementsPrism.getOptionalOn(analysedComponent.element().getAccessor())
+        xmlElementsPrism(analysedComponent)
             .ifPresent(outerPrism -> {
                 for (final XmlElementPrism prism : outerPrism.value()) {
                     final ClassName className = ClassName.get(APContext.asTypeElement(prism.type()));
@@ -183,7 +181,7 @@ public class Branching extends XmlVisitor {
         return analysedComponent.targetAnalysedType()
             .filter(x -> (analysedComponent.requiresUnwrapping()))
             .filter(x -> !(analysedComponent instanceof AnalysedOptionalComponent))
-            .filter(x -> XmlElementsPrism.isPresent(analysedComponent.element().getAccessor()))
+            .filter(x -> xmlElementsPrism(analysedComponent).isPresent())
             .filter(AnalysedInterface.class::isInstance)
             .map(AnalysedInterface.class::cast);
     }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/collections/WriteCharSequence.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/collections/WriteCharSequence.java
@@ -40,13 +40,13 @@ public class WriteCharSequence extends XmlVisitor {
 
     @Override
     protected boolean visitComponentImpl(AnalysedComponent analysedComponent) {
-        final Optional<XmlElementPrism> optPrism = XmlElementPrism.getOptionalOn(analysedComponent.element().getAccessor());
+        final Optional<XmlElementPrism> optPrism = xmlElementPrism(analysedComponent);
         if (isSupported(analysedComponent, optPrism)) {
             final XmlElementPrism prism = optPrism.get();
             final String elementName = elementName(analysedComponent, prism);
             final boolean required = Boolean.TRUE.equals(prism.required());
             final Optional<String> defaultValue = defaultValue(prism);
-            final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+            final Optional<String> namespaceName = namespaceName(prism);
             final MethodSpec.Builder methodBuilder = createMethod(analysedComponent, analysedComponent.typeName());
 
             if (defaultValue.isPresent()) {

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/collections/WriteOtherProcessed.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/collections/WriteOtherProcessed.java
@@ -56,7 +56,7 @@ public class WriteOtherProcessed extends XmlVisitor {
 
     @Override
     protected boolean visitComponentImpl(AnalysedComponent analysedComponent) {
-        final Optional<XmlElementPrism> optPrism = XmlElementPrism.getOptionalOn(analysedComponent.element().getAccessor());
+        final Optional<XmlElementPrism> optPrism = xmlElementPrism(analysedComponent);
         final var otherOpt = extractSupported(analysedComponent, optPrism);
         if (optPrism.isPresent() && otherOpt.isPresent()) {
             final XmlElementPrism prism = optPrism.get();
@@ -64,7 +64,7 @@ public class WriteOtherProcessed extends XmlVisitor {
             final String elementName = elementName(analysedComponent, prism);
             final boolean required = Boolean.TRUE.equals(prism.required());
             final Optional<String> defaultValue = defaultValue(prism);
-            final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+            final Optional<String> namespaceName = namespaceName(prism);
             final MethodSpec.Builder methodBuilder = createMethod(analysedComponent, analysedComponent.typeName());
             final ClassName otherXmlUtils = other.utilsClassChildClass(XML_UTILS_CLASS, Claims.XML_STATIC_CLASS).className();
             analysedComponent.addCrossReference(other);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/Branching.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/Branching.java
@@ -15,6 +15,7 @@ import java.util.function.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
 
+import io.avaje.spi.ServiceProvider;
 import io.github.cbarlin.aru.core.APContext;
 import io.github.cbarlin.aru.core.artifacts.PreBuilt;
 import io.github.cbarlin.aru.core.types.AnalysedComponent;
@@ -25,9 +26,6 @@ import io.github.cbarlin.aru.core.types.ProcessingTarget;
 import io.github.cbarlin.aru.impl.Constants.Claims;
 import io.github.cbarlin.aru.impl.xml.XmlVisitor;
 import io.github.cbarlin.aru.prism.prison.XmlElementPrism;
-import io.github.cbarlin.aru.prism.prison.XmlElementsPrism;
-
-import io.avaje.spi.ServiceProvider;
 import io.micronaut.sourcegen.javapoet.ClassName;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
 
@@ -117,7 +115,7 @@ public class Branching extends XmlVisitor {
 
     private Map<ClassName, NameAndNamespace> extractNamedVersions(final AnalysedComponent analysedComponent, final AnalysedInterface other) {
         final Map<ClassName, NameAndNamespace> extracted = HashMap.newHashMap(other.implementingTypes().size());
-        XmlElementsPrism.getOptionalOn(analysedComponent.element().getAccessor())
+        xmlElementsPrism(analysedComponent)
             .ifPresent(outerPrism -> {
                 for (final XmlElementPrism prism : outerPrism.value()) {
                     final ClassName className = ClassName.get(APContext.asTypeElement(prism.type()));
@@ -145,7 +143,7 @@ public class Branching extends XmlVisitor {
     private Optional<AnalysedInterface> extractSupported(final AnalysedComponent analysedComponent) {
         return analysedComponent.targetAnalysedType()
             .filter(x -> (!analysedComponent.requiresUnwrapping()))
-            .filter(x -> XmlElementPrism.isPresent(analysedComponent.element().getAccessor()))
+            .filter(x -> xmlElementsPrism(analysedComponent).isPresent())
             .filter(AnalysedInterface.class::isInstance)
             .map(AnalysedInterface.class::cast);
     }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteCharSequence.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteCharSequence.java
@@ -38,14 +38,14 @@ public class WriteCharSequence extends XmlVisitor {
 
     @Override
     protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
-        final Optional<XmlElementPrism> optPrism = XmlElementPrism.getOptionalOn(analysedComponent.element().getAccessor());
+        final Optional<XmlElementPrism> optPrism = xmlElementPrism(analysedComponent);
         if (optPrism.isPresent() && (!analysedComponent.requiresUnwrapping()) && APContext.types().isSubtype(analysedComponent.componentType(), APContext.elements().getTypeElement(CharSequence.class.getCanonicalName()).asType())) {
             // Nice!
             final XmlElementPrism prism = optPrism.get();
             final String elementName = elementName(analysedComponent, prism);
             final boolean required = Boolean.TRUE.equals(prism.required());
             final Optional<String> defaultValue = defaultValue(prism);
-            final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+            final Optional<String> namespaceName = namespaceName(prism);
             final MethodSpec.Builder methodBuilder = createMethod(analysedComponent, CHAR_SEQUENCE);
             
             if (defaultValue.isPresent()) {

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteOffsetDatetime.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteOffsetDatetime.java
@@ -36,14 +36,14 @@ public class WriteOffsetDatetime extends XmlVisitor {
 
     @Override
     protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
-        final Optional<XmlElementPrism> optPrism = XmlElementPrism.getOptionalOn(analysedComponent.element().getAccessor());
+        final Optional<XmlElementPrism> optPrism = xmlElementPrism(analysedComponent);
         if (optPrism.isPresent() && OFFSET_DATE_TIME.equals(analysedComponent.typeName())) {
             // Nice!
             final XmlElementPrism prism = optPrism.get();
             final String elementName = elementName(analysedComponent, prism);
             final boolean required = Boolean.TRUE.equals(prism.required());
             final Optional<String> defaultValue = defaultValue(prism);
-            final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+            final Optional<String> namespaceName = namespaceName(prism);
             final MethodSpec.Builder methodBuilder = createMethod(analysedComponent, analysedComponent.typeName());
             
             if (defaultValue.isPresent()) {

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteOtherProcessed.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteOtherProcessed.java
@@ -36,14 +36,14 @@ public class WriteOtherProcessed extends XmlVisitor {
 
     @Override
     protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
-        final Optional<XmlElementPrism> optPrism = XmlElementPrism.getOptionalOn(analysedComponent.element().getAccessor());
+        final Optional<XmlElementPrism> optPrism = xmlElementPrism(analysedComponent);
         final Optional<ProcessingTarget> targetAnalysedType = analysedComponent.targetAnalysedType();
         if (optPrism.isPresent() && (!analysedComponent.requiresUnwrapping()) && targetAnalysedType.isPresent() && targetAnalysedType.get() instanceof final AnalysedRecord other) {
             final XmlElementPrism prism = optPrism.get();
             final String elementName = elementName(analysedComponent, prism);
             final boolean required = Boolean.TRUE.equals(prism.required());
             final Optional<String> defaultValue = defaultValue(prism);
-            final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+            final Optional<String> namespaceName = namespaceName(prism);
             final MethodSpec.Builder methodBuilder = createMethod(analysedComponent, analysedComponent.typeName());
             analysedComponent.addCrossReference(other);
 

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteUUID.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteUUID.java
@@ -32,13 +32,13 @@ public class WriteUUID extends XmlVisitor {
 
     @Override
     protected boolean visitComponentImpl(AnalysedComponent analysedComponent) {
-        final Optional<XmlElementPrism> optPrism = XmlElementPrism.getOptionalOn(analysedComponent.element().getAccessor());
+        final Optional<XmlElementPrism> optPrism = xmlElementPrism(analysedComponent);
         if (UUID.equals(analysedComponent.typeName()) && optPrism.isPresent()) {
             final XmlElementPrism prism = optPrism.get();
             final String elementName = elementName(analysedComponent, prism);
             final boolean required = Boolean.TRUE.equals(prism.required());
             final Optional<String> defaultValue = defaultValue(prism);
-            final Optional<String> namespaceName = namespaceName(analysedComponent, prism);
+            final Optional<String> namespaceName = namespaceName(prism);
             final MethodSpec.Builder methodBuilder = createMethod(analysedComponent, UUID);
 
             if (defaultValue.isPresent()) {

--- a/aru-prism-prison/pom.xml
+++ b/aru-prism-prison/pom.xml
@@ -16,6 +16,10 @@
     <description>
         A package that has prisms for generating annotations, without needing to explicitly needing to include them in the final processor dependency tree.
     </description>
+    <url>https://github.com/cbarlin/advanced-record-utils</url>
+    <scm>
+        <url>https://github.com/cbarlin/advanced-record-utils</url>
+    </scm>
 
     <dependencies>
         <dependency>

--- a/aru-prism-prison/src/main/java/io/github/cbarlin/aru/prism/prison/PrismGenerator.java
+++ b/aru-prism-prison/src/main/java/io/github/cbarlin/aru/prism/prison/PrismGenerator.java
@@ -51,6 +51,7 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapters;
 @GeneratePrism(publicAccess = true, value = Json.Value.class, name = "JsonBValuePrism")
 @GeneratePrism(publicAccess = true, value = Json.SubType.class, name = "JsonBSubTypePrism")
 @GeneratePrism(publicAccess = true, value = Json.SubTypes.class, name = "JsonBSubTypesPrism")
+@GeneratePrism(publicAccess = true, value = Json.Property.class, name = "JsonBPropertyPrism")
 @GeneratePrism(publicAccess = true, value = CustomAdapter.class, name = "JsonBCustomAdaptorPrism")
 // Jakarta XML
 @GeneratePrism(publicAccess = true, value = XmlAttribute.class)

--- a/aru-processor-core/pom.xml
+++ b/aru-processor-core/pom.xml
@@ -12,6 +12,10 @@
     <description>Core library to be used by the processor, containing utility objects. Not intended to be used by end-users, as it aims to isolate the backbone of the processor from its features</description>
     <artifactId>aru-processor-core</artifactId>
     <packaging>jar</packaging>
+    <url>https://github.com/cbarlin/advanced-record-utils</url>
+    <scm>
+        <url>https://github.com/cbarlin/advanced-record-utils</url>
+    </scm>
 
     <properties>
         <micronaut-javapoet.version>1.7.7</micronaut-javapoet.version>

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/CommonsConstants.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/CommonsConstants.java
@@ -13,9 +13,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
-import io.github.cbarlin.aru.annotations.AdvancedRecordUtilsGenerated;
-
 import io.micronaut.sourcegen.javapoet.ClassName;
 
 /**
@@ -44,6 +41,7 @@ public enum CommonsConstants {
         private static final String ADVANCED_RECORD_UTILS_GENERATED = "AdvancedRecordUtilsGenerated";
         private static final String IO_GITHUB_CBARLIN_ARU_ANNOTATIONS = "io.github.cbarlin.aru.annotations";
         private static final String ORG_JSPECIFY_ANNOTATIONS = "org.jspecify.annotations";
+        private static final String JAKARTA_XML_BIND = "jakarta.xml.bind.annotation";
         public static final ClassName NON_NULL = ClassName.get(ORG_JSPECIFY_ANNOTATIONS, "NonNull");
         public static final ClassName NULL_MARKED = ClassName.get(ORG_JSPECIFY_ANNOTATIONS, "NullMarked");
         public static final ClassName NULL_UNMARKED = ClassName.get(ORG_JSPECIFY_ANNOTATIONS, "NullUnmarked");
@@ -66,6 +64,7 @@ public enum CommonsConstants {
         public static final ClassName COLLECTORS = ClassName.get(Collectors.class);
         public static final ClassName COLLECTION = ClassName.get(Collection.class);
         public static final ClassName UNSUPPORTED_OPERATION_EXCEPTION = ClassName.get(UnsupportedOperationException.class);
+        public static final ClassName XML_SEE_ALSO = ClassName.get(JAKARTA_XML_BIND, "XmlSeeAlso");
 
 
         // Cross references the above. Used to resolve confusion

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/UtilsProcessingContext.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/UtilsProcessingContext.java
@@ -16,6 +16,8 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 
+import org.jspecify.annotations.Nullable;
+
 import io.github.cbarlin.aru.core.artifacts.PreBuilt;
 import io.github.cbarlin.aru.core.types.AnalysedInterface;
 import io.github.cbarlin.aru.core.types.AnalysedRecord;
@@ -41,6 +43,10 @@ public class UtilsProcessingContext {
 
     public ProcessingEnvironment processingEnv() {
         return processingEnvironment;
+    }
+
+    public @Nullable ProcessingTarget analysedType(final TypeElement typeElement) {
+        return analysedTypes.get(typeElement);
     }
 
     public void processElements(final Supplier<List<RecordVisitor>> visitorSupplier) {

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/inference/AnnotationInferencer.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/inference/AnnotationInferencer.java
@@ -1,0 +1,44 @@
+package io.github.cbarlin.aru.core.inference;
+
+import java.util.Optional;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.type.TypeMirror;
+
+import io.avaje.spi.Service;
+import io.github.cbarlin.aru.core.AdvancedRecordUtilsPrism;
+import io.github.cbarlin.aru.core.UtilsProcessingContext;
+import io.micronaut.sourcegen.javapoet.ClassName;
+
+/**
+ * A class that can "infer" a {@link TypeMirror} 
+ */
+@Service
+public interface AnnotationInferencer extends Comparable<AnnotationInferencer> {
+
+    /**
+     * How specific is this inferrer?
+     */
+    public int specificity();
+
+    /**
+     * The class name of the annotation
+     */
+    public ClassName supportedAnnotationClassName();
+
+    /**
+     * Attempt to create a type mirror with values inferred from other items
+     */
+    public Optional<AnnotationMirror> inferAnnotationMirror(final Element element, final UtilsProcessingContext processingContext, final AdvancedRecordUtilsPrism prism);
+
+    // We don't need to also override equals, as we won't be `equals` them since that doesn't make sense
+    @SuppressWarnings({"java:S1210"})
+    @Override
+    default int compareTo(AnnotationInferencer o) {
+        if (specificity() == o.specificity()) {
+            return getClass().getName().compareTo(o.getClass().getName());
+        }
+        return Integer.compare(specificity(), o.specificity());
+    }
+}

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/inference/ClassNameToPrismAdaptor.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/inference/ClassNameToPrismAdaptor.java
@@ -1,0 +1,28 @@
+package io.github.cbarlin.aru.core.inference;
+
+import java.util.Optional;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+
+import io.avaje.spi.Service;
+import io.micronaut.sourcegen.javapoet.ClassName;
+
+/**
+ * An adaptor that knows how to swap a type name for a prism
+ */
+@Service
+public interface ClassNameToPrismAdaptor<T> {
+
+    public ClassName supportedAnnotationClassName();
+
+    public Class<T> prismClass();
+
+    default ClassName supportedPrismClassName() {
+        return ClassName.get(prismClass());
+    }
+
+    public Optional<T> optionalInstanceOf(final AnnotationMirror typeMirror);
+
+    public Optional<T> optionalInstanceOn(final Element element);
+}

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/inference/Holder.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/inference/Holder.java
@@ -1,0 +1,42 @@
+package io.github.cbarlin.aru.core.inference;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.ServiceLoader;
+
+public class Holder {
+
+    private static List<ClassNameToPrismAdaptor> CLASS_NAME_PRISM_ADAPTORS;
+    private static List<AnnotationInferencer> INFERENCERS;
+
+    public static List<ClassNameToPrismAdaptor> adaptors() {
+        if (Objects.isNull(CLASS_NAME_PRISM_ADAPTORS)) {
+            final List<ClassNameToPrismAdaptor> lst = new ArrayList<>();
+            
+            ServiceLoader.load(
+                ClassNameToPrismAdaptor.class,
+                ClassNameToPrismAdaptor.class.getClassLoader()
+            )
+            .forEach(lst::add);
+            CLASS_NAME_PRISM_ADAPTORS = List.copyOf(lst);
+        }
+        return CLASS_NAME_PRISM_ADAPTORS;
+    }
+
+    public static List<AnnotationInferencer> inferencers() {
+        if (Objects.isNull(INFERENCERS)) {
+            final List<AnnotationInferencer> lst = new ArrayList<>();
+            
+            ServiceLoader.load(
+                AnnotationInferencer.class,
+                AnnotationInferencer.class.getClassLoader()
+            )
+            .forEach(lst::add);
+            Collections.sort(lst);
+            INFERENCERS = List.copyOf(lst);
+        }
+        return INFERENCERS;
+    }
+}

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/mirrorhandlers/MapBasedAnnotationMirror.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/mirrorhandlers/MapBasedAnnotationMirror.java
@@ -1,0 +1,85 @@
+package io.github.cbarlin.aru.core.mirrorhandlers;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.github.cbarlin.aru.core.APContext;
+import io.micronaut.sourcegen.javapoet.ClassName;
+
+public class MapBasedAnnotationMirror implements AnnotationMirror {
+
+    private final Map<ExecutableElement, AnnotationValue> elementValues;
+    private final DeclaredType declaredType;
+
+    public MapBasedAnnotationMirror(final ClassName annotationClassName) {
+        this(annotationClassName, Map.of());
+    }
+
+    public MapBasedAnnotationMirror(final ClassName annotationClassName, Optional<Map<String, Object>> values) {
+        this(annotationClassName, values.orElse(Map.of()));
+    }
+
+    public MapBasedAnnotationMirror(final ClassName annotationClassName, final Map<String, Object> values) {
+        final Optional<TypeElement> optAte = Optional.ofNullable(APContext.typeElement(annotationClassName.canonicalName()))
+            .filter((TypeElement te) -> ElementKind.ANNOTATION_TYPE.equals(te.getKind()));
+        
+        this.declaredType = optAte
+            .map(TypeElement::asType)
+            .filter(DeclaredType.class::isInstance)
+            .map(DeclaredType.class::cast)
+            .orElseThrow(() -> new NoSuchElementException("Cannot obtain a declared type of " + annotationClassName.canonicalName()));
+        
+        final TypeElement typeElement = optAte.get();
+        
+        final Map<ExecutableElement, AnnotationValue> out = HashMap.newHashMap(values.size());
+        values.forEach((String key, Object value) -> {
+            if (StringUtils.isBlank(key) || Objects.isNull(value)) {
+                return;
+            }
+            final Optional<ExecutableElement> opt = typeElement.getEnclosedElements()
+                .stream()
+                .filter(ExecutableElement.class::isInstance)
+                .map(ExecutableElement.class::cast)
+                .filter(exec -> key.equals(exec.getSimpleName().toString()))
+                .findFirst();
+            if (opt.isPresent()) {
+                final ExecutableElement nKey = opt.get();
+                final AnnotationValue nValue = switch(value) {
+                    case final Collection<?> col when (!col.isEmpty()) -> new SyntheticAnnotationValue(col.stream().filter(Objects::nonNull).map(SyntheticAnnotationValue::new).toList());
+                    case final Collection<?> col when (col.isEmpty()) -> new SyntheticAnnotationValue(List.of());
+                    case final Class<?> clz -> new SyntheticAnnotationValue(APContext.elements().getTypeElement(ClassName.get(clz).canonicalName()).asType());
+                    case final ClassName clz -> new SyntheticAnnotationValue(APContext.elements().getTypeElement(clz.canonicalName()).asType());
+                    case final Enum<?> enm -> throw new UnsupportedOperationException("No support yet for enums");
+                    case null, default -> new SyntheticAnnotationValue(value);
+                };
+                out.put(nKey, nValue);
+            }
+        });
+
+        this.elementValues = Map.copyOf(out);
+    }
+
+    @Override
+    public Map<ExecutableElement, AnnotationValue> getElementValues() {
+        return elementValues;
+    }
+
+    @Override
+    public DeclaredType getAnnotationType() {
+        return declaredType;
+    }
+}

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/mirrorhandlers/SyntheticAnnotationValue.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/mirrorhandlers/SyntheticAnnotationValue.java
@@ -1,0 +1,49 @@
+package io.github.cbarlin.aru.core.mirrorhandlers;
+
+import java.util.List;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.AnnotationValueVisitor;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+
+public record SyntheticAnnotationValue(Object value) implements AnnotationValue {
+
+    @Override
+    public Object getValue() {
+        return value;
+    }
+
+    /**
+     * This shouldn't be needed... Surely not...
+     */
+    @Override
+    public final String toString() {
+        return value.toString();
+    }
+
+    // Since we are constructing these... they should always be valid
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R, P> R accept(final AnnotationValueVisitor<R, P> v, final P p) {
+        return switch (value) {
+            case final Boolean b -> v.visitBoolean(b, p);
+            case final Byte b -> v.visitByte(b, p);
+            case final Character c -> v.visitChar(c, p);
+            case final Double d -> v.visitDouble(d, p);
+            case final Float f -> v.visitFloat(f, p);
+            case final Integer i -> v.visitInt(i, p);
+            case final Long l -> v.visitLong(l, p);
+            case final Short s -> v.visitShort(s, p);
+            case final String str -> v.visitString(str, p);
+            case final TypeMirror tm -> v.visitType(tm, p);
+            case final VariableElement ve when ElementKind.ENUM_CONSTANT.equals(ve.getKind()) -> v.visitEnumConstant(ve, p);
+            case final AnnotationMirror am -> v.visitAnnotation(am, p);
+            case final List<?> lst when (!lst.isEmpty()) && (lst.get(0) instanceof AnnotationValue) -> v.visitArray( (List<AnnotationValue>) lst, p);
+            case final List<?> lst when lst.isEmpty() -> v.visitArray(List.of(), p);
+            case null, default -> v.visitUnknown(this, p);
+        };
+    }
+}

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/types/AnalysedComponent.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/types/AnalysedComponent.java
@@ -20,8 +20,8 @@ import io.github.cbarlin.aru.core.AdvRecUtilsSettings;
 import io.github.cbarlin.aru.core.ClaimableOperation;
 import io.github.cbarlin.aru.core.UtilsProcessingContext;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.inference.Holder;
 import io.github.cbarlin.aru.core.visitors.RecordVisitor;
-
 import io.micronaut.sourcegen.javapoet.ClassName;
 import io.micronaut.sourcegen.javapoet.TypeName;
 
@@ -36,7 +36,6 @@ public class AnalysedComponent {
      * Annotations that are not on the RecordComponentElement (and/or accessor or field) but are "projected"
      *   into it that may be relevent (e.g. `NotNull` which is implied from a package annotation)
      */
-    protected final Map<ClassName, List<AnnotationMirror>> projectedRelevantAnnotations = new HashMap<>();
     protected Optional<ProcessingTarget> targetAnalysedType = Optional.empty();
     protected final TypeName typeName;
     protected final List<AnalysedTypeConverter> analysedTypeConverters;
@@ -228,10 +227,6 @@ public class AnalysedComponent {
             .map(ClassName::get);
     }
 
-    public Map<ClassName, List<AnnotationMirror>> projectedRelevantAnnotations() {
-        return Map.copyOf(projectedRelevantAnnotations);
-    }
-
     public Optional<ProcessingTarget> targetAnalysedType() {
         return targetAnalysedType;
     }
@@ -252,5 +247,39 @@ public class AnalysedComponent {
     public String toString() {
         return className().map(ClassName::canonicalName)
             .orElse(typeName().toString());
+    }
+
+    protected final Map<ClassName, Optional> annotations = new HashMap<>();
+
+    public <T> Optional<T> findPrism(ClassName annotationClassName, Class<T> prismClass) {
+        return (Optional<T>) annotations.computeIfAbsent(annotationClassName, c -> findPrismImpl(c, prismClass));
+    }
+
+    private <T> Optional<T> findPrismImpl(ClassName annotationClassName, Class<T> prismClass) {
+        return Holder.adaptors().stream()
+            .filter(cn -> annotationClassName.equals(cn.supportedAnnotationClassName()))
+            .map(cn -> cn.optionalInstanceOn(element))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .filter(prismClass::isInstance)
+            .map(prismClass::cast)
+            .findFirst()
+            .or(
+                () -> Holder.inferencers().stream()
+                        .filter(inf -> annotationClassName.equals(inf.supportedAnnotationClassName()))
+                        .map(inf -> inf.inferAnnotationMirror(element, context, parentRecord().prism()))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .flatMap(
+                            (AnnotationMirror tm) -> Holder.adaptors().stream()
+                                    .filter(cn -> annotationClassName.equals(cn.supportedAnnotationClassName()))
+                                    .map(cn -> cn.optionalInstanceOf(tm))
+                                    .filter(Optional::isPresent)
+                                    .map(Optional::get)
+                                    .filter(prismClass::isInstance)
+                                    .map(prismClass::cast)
+                        )
+                        .findFirst()
+            );
     }
 }

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/types/AnalysedType.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/types/AnalysedType.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -26,6 +27,7 @@ import io.github.cbarlin.aru.core.CommonsConstants.Names;
 import io.github.cbarlin.aru.core.UtilsProcessingContext;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuiltClass;
+import io.github.cbarlin.aru.core.inference.Holder;
 import io.github.cbarlin.aru.core.visitors.RecordVisitor;
 
 import io.micronaut.sourcegen.javapoet.AnnotationSpec;
@@ -244,4 +246,38 @@ public abstract sealed class AnalysedType implements ProcessingTarget permits An
         return className().canonicalName();
     }
     //#endregion
+
+    protected final Map<ClassName, Optional> annotations = new HashMap<>();
+
+    public <T> Optional<T> findPrism(ClassName annotationClassName, Class<T> prismClass) {
+        return (Optional<T>) annotations.computeIfAbsent(annotationClassName, c -> findPrismImpl(c, prismClass));
+    }
+
+    private <T> Optional<T> findPrismImpl(ClassName annotationClassName, Class<T> prismClass) {
+        return Holder.adaptors().stream()
+            .filter(cn -> annotationClassName.equals(cn.supportedAnnotationClassName()))
+            .map(cn -> cn.optionalInstanceOn(typeElement))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .filter(prismClass::isInstance)
+            .map(prismClass::cast)
+            .findFirst()
+            .or(
+                () -> Holder.inferencers().stream()
+                        .filter(inf -> annotationClassName.equals(inf.supportedAnnotationClassName()))
+                        .map(inf -> inf.inferAnnotationMirror(typeElement, utilsProcessingContext, prism()))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .flatMap(
+                            (AnnotationMirror tm) -> Holder.adaptors().stream()
+                                    .filter(cn -> annotationClassName.equals(cn.supportedAnnotationClassName()))
+                                    .map(cn -> cn.optionalInstanceOf(tm))
+                                    .filter(Optional::isPresent)
+                                    .map(Optional::get)
+                                    .filter(prismClass::isInstance)
+                                    .map(prismClass::cast)
+                        )
+                        .findFirst()
+            );
+    }
 }

--- a/aru-processor-core/src/main/java/module-info.java
+++ b/aru-processor-core/src/main/java/module-info.java
@@ -20,6 +20,8 @@ module io.github.cbarlin.aru.core {
 
     uses io.github.cbarlin.aru.core.visitors.RecordVisitor;
     uses io.github.cbarlin.aru.core.types.ComponentAnalyser;
+    uses io.github.cbarlin.aru.core.inference.AnnotationInferencer;
+    uses io.github.cbarlin.aru.core.inference.ClassNameToPrismAdaptor;
 
     provides io.github.cbarlin.aru.core.visitors.RecordVisitor
             with io.github.cbarlin.aru.core.impl.visitors.BuilderClassCreatorVisitor,


### PR DESCRIPTION
Fixes #21, Fixes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for advanced annotation inference and prism adaptation, enabling more flexible annotation processing and XML mapping.
  - Added new interfaces and classes to facilitate annotation inference, prism adaptation, and programmatic annotation mirror/value creation.
  - Added new type alias interfaces for Integer, Long, String, and UUID values with built-in comparison support.
- **Enhancements**
  - Improved caching and retrieval of annotation prisms for types and components, supporting both direct and inferred annotations.
  - Extended XML processing capabilities with new mappers and helpers for XML annotations.
  - Enhanced module descriptors and project metadata with project and source control URLs.
- **Documentation**
  - Added Javadoc comments and improved module documentation for better clarity and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->