### PR TITLE
Create wither method to accept de-aliased type

### DIFF
--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
@@ -43,6 +43,7 @@ public enum Constants {
         public static final ClaimableOperation WITHER_TO_BUILDER = new ClaimableOperation("witherToBuilder", CLASS);
         public static final ClaimableOperation WITHER_USE_TYPE_CONVERTER = new ClaimableOperation("witherUseTypeConverter", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation WITHER_WITH = new ClaimableOperation("witherWith", FIELD_AND_ACCESSORS);
+        public static final ClaimableOperation WITHER_WITH_ALIAS = new ClaimableOperation("witherWithAlias", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation WITHER_WITH_ADD = new ClaimableOperation("witherWithAdd", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation WITHER_WITH_FLUENT = new ClaimableOperation("witherWithFluent", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation XML_IFACE = new ClaimableOperation("xmlInterface", CLASS);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/wither/WithAlias.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/wither/WithAlias.java
@@ -1,0 +1,59 @@
+package io.github.cbarlin.aru.impl.wither;
+
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.NON_NULL;
+
+import javax.lang.model.element.Modifier;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.types.AnalysedRecord;
+import io.github.cbarlin.aru.impl.Constants.Claims;
+import io.github.cbarlin.aru.impl.types.TypeAliasComponent;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+
+@ServiceProvider
+public class WithAlias extends WitherVisitor {
+
+    public WithAlias() {
+        super(Claims.WITHER_WITH_ALIAS);
+    }
+
+    @Override
+    protected int witherSpecificity() {
+        return 3;
+    }
+
+    @Override
+    protected boolean isWitherApplicable(AnalysedRecord analysedRecord) {
+        // Only bother if the record has at least one TypeAlias component
+        return analysedRecord.components()
+            .stream()
+            .anyMatch(TypeAliasComponent.class::isInstance);
+    }
+
+    @Override
+    protected boolean visitComponentImpl(AnalysedComponent analysedComponent) {
+        if (analysedComponent.isIntendedConstructorParam() && analysedComponent instanceof TypeAliasComponent typeAliasComponent) {
+            final String name = typeAliasComponent.name();
+            final String withMethodName = witherOptionsPrism.withMethodPrefix() + capitalise(name) + witherOptionsPrism.withMethodSuffix();
+            final MethodSpec.Builder methodBuilder = witherInterface.createMethod(withMethodName, claimableOperation, analysedComponent)
+                .addAnnotation(NON_NULL)
+                .returns(analysedComponent.parentRecord().intendedType())
+                .addModifiers(Modifier.DEFAULT)
+                .addJavadoc("Return a new instance with a different {@code $L} field", name)
+                .addParameter(
+                    ParameterSpec.builder(typeAliasComponent.serialisedTypeName(), name, Modifier.FINAL)
+                        .addJavadoc("Replacement value")
+                        .build()
+                )
+                // No need to handle null as this will eventually make its way down to the builder which will do that for us
+                .addStatement("return this.$L(new $T($L))", withMethodName, typeAliasComponent.typeName(), name);
+            AnnotationSupplier.addGeneratedAnnotation(methodBuilder, this);
+            return true;
+        }
+        return false;
+    }
+    
+}

--- a/utils-tests/b_type_alias/src/main/java/io/github/cbarlin/aru/tests/b_types_alias/SomeRecord.java
+++ b/utils-tests/b_type_alias/src/main/java/io/github/cbarlin/aru/tests/b_types_alias/SomeRecord.java
@@ -18,6 +18,6 @@ public record SomeRecord(
     RandomIntB randomIntB,
     @XmlAttribute(name = "C")
     RandomIntC randomIntC
-) {
+) implements SomeRecordUtils.All {
 
 }

--- a/utils-tests/b_type_alias/src/test/java/io/github/cbarlin/aru/tests/b_types_alias/BuilderTests.java
+++ b/utils-tests/b_type_alias/src/test/java/io/github/cbarlin/aru/tests/b_types_alias/BuilderTests.java
@@ -17,8 +17,9 @@ class BuilderTests {
             .randomIntB(new RandomIntB(69))
             .randomIntC(13)
             .build();
-        // Test both that we have constructions of records and that we can destruct them
+        // Test both that we have constructions of aliases...
         assertEquals(new RandomIntA(42), someRecord.randomIntA());
+        // ... and that we can dealias them...
         assertEquals("This is an author", someRecord.authorName().value());        
         assertEquals("And this is a book", someRecord.bookName().value());
         assertEquals(69, someRecord.randomIntB().value());

--- a/utils-tests/b_type_alias/src/test/java/io/github/cbarlin/aru/tests/b_types_alias/WitherTests.java
+++ b/utils-tests/b_type_alias/src/test/java/io/github/cbarlin/aru/tests/b_types_alias/WitherTests.java
@@ -1,16 +1,27 @@
 package io.github.cbarlin.aru.tests.b_types_alias;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
 
 class WitherTests {
 
-    void canHandleReplacementWithDelaias() {
+    @Test
+    void canHandleReplacementWithDealias() {
         final SomeRecord original = SomeRecordUtils.builder()
             .randomIntA(69)
+            .bookName("This is a bookname")
+            .authorName("This is the author name")
+            .randomIntB(13)
             .build();
-        final SomeRecord after = original.withRandomIntA(42);
+        final SomeRecord after = original.withRandomIntA(42)
+            .withBookName((BookName) null);
 
         assertEquals(69, original.randomIntA().value());
         assertEquals(42, after.randomIntA().value());
+        assertNull(after.bookName());
+        assertEquals(original.authorName(), after.authorName());
+        assertEquals(original.randomIntB(), after.randomIntB());
     }
 }

--- a/utils-tests/b_type_alias/src/test/java/io/github/cbarlin/aru/tests/b_types_alias/WitherTests.java
+++ b/utils-tests/b_type_alias/src/test/java/io/github/cbarlin/aru/tests/b_types_alias/WitherTests.java
@@ -1,0 +1,16 @@
+package io.github.cbarlin.aru.tests.b_types_alias;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WitherTests {
+
+    void canHandleReplacementWithDelaias() {
+        final SomeRecord original = SomeRecordUtils.builder()
+            .randomIntA(69)
+            .build();
+        final SomeRecord after = original.withRandomIntA(42);
+
+        assertEquals(69, original.randomIntA().value());
+        assertEquals(42, after.randomIntA().value());
+    }
+}


### PR DESCRIPTION
Fixes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for generating "with" methods for record components that are type aliases, enabling fluent updates of those fields.
- **Tests**
  - Added tests to verify correct behaviour of the new "with" methods for type alias components.
- **Documentation**
  - Improved comments in tests to clarify intent and behaviour.
- **Enhancements**
  - Updated record declarations to implement utility interfaces for improved integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->