### PR TITLE
Add XML Element Numerics

### DIFF
--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
@@ -68,6 +68,8 @@ public enum Constants {
         public static final ClassName AVAJE_JSONB_IMPORT = ClassName.get("io.avaje.jsonb", "Json", "Import");
         public static final ClassName AVAJE_VALIDATOR = ClassName.get("io.avaje.validation", "Validator");
         public static final ClassName BI_CONSUMER = ClassName.get(BiConsumer.class);
+        public static final ClassName BIG_DECIMAL = ClassName.get("java.math", "BigDecimal");
+        public static final ClassName BIG_INTEGER = ClassName.get("java.math", "BigInteger");
         public static final ClassName CHAR_SEQUENCE = ClassName.get(CharSequence.class);
         public static final ClassName CONSTRAINT_VIOLATION = ClassName.get("jakarta.validation", "ConstraintViolation");
         public static final ClassName CONSUMER = ClassName.get(Consumer.class);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBigDecimal.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBigDecimal.java
@@ -1,0 +1,48 @@
+package io.github.cbarlin.aru.impl.xml.utils.attribute;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.BIG_DECIMAL;
+import static io.github.cbarlin.aru.impl.Constants.Names.OBJECTS;
+
+import java.util.Optional;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.prism.prison.XmlAttributePrism;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+@ServiceProvider
+public class WriteBigDecimal extends WriteXmlAttribute {
+    public WriteBigDecimal() {
+        super();
+    }
+
+    @Override
+    TypeName supportedTypeName() {
+        return BIG_DECIMAL;
+    }
+
+    @Override
+    void visitAttributeComponent(AnalysedComponent analysedComponent, XmlAttributePrism prism) {
+        final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
+        final boolean required = Boolean.TRUE.equals(prism.required());
+        final String attributeName = attributeName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
+
+        if (required) {
+            final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);
+            methodBuilder.addStatement("$T.requireNonNull(val, $S)", OBJECTS, errMsg);
+        } else {
+            methodBuilder.beginControlFlow("if ($T.nonNull(val))", OBJECTS);
+        }
+
+        namespaceName.ifPresentOrElse(
+            namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, val.toString())", namespace, attributeName),
+            () -> methodBuilder.addStatement("output.writeAttribute($S, val.toString())", attributeName)
+        );
+
+        if (!required) {
+            methodBuilder.endControlFlow();
+        }
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBigInteger.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBigInteger.java
@@ -1,0 +1,48 @@
+package io.github.cbarlin.aru.impl.xml.utils.attribute;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.BIG_INTEGER;
+import static io.github.cbarlin.aru.impl.Constants.Names.OBJECTS;
+
+import java.util.Optional;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.prism.prison.XmlAttributePrism;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+@ServiceProvider
+public class WriteBigInteger extends WriteXmlAttribute {
+    public WriteBigInteger() {
+        super();
+    }
+
+    @Override
+    TypeName supportedTypeName() {
+        return BIG_INTEGER;
+    }
+
+    @Override
+    void visitAttributeComponent(AnalysedComponent analysedComponent, XmlAttributePrism prism) {
+        final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
+        final boolean required = Boolean.TRUE.equals(prism.required());
+        final String attributeName = attributeName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
+
+        if (required) {
+            final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);
+            methodBuilder.addStatement("$T.requireNonNull(val, $S)", OBJECTS, errMsg);
+        } else {
+            methodBuilder.beginControlFlow("if ($T.nonNull(val))", OBJECTS);
+        }
+
+        namespaceName.ifPresentOrElse(
+            namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, val.toString())", namespace, attributeName),
+            () -> methodBuilder.addStatement("output.writeAttribute($S, val.toString())", attributeName)
+        );
+
+        if (!required) {
+            methodBuilder.endControlFlow();
+        }
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedByte.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteBoxedByte.java
@@ -1,0 +1,51 @@
+package io.github.cbarlin.aru.impl.xml.utils.attribute;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.OBJECTS;
+import static io.github.cbarlin.aru.impl.Constants.Names.STRING;
+
+import java.util.Optional;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.prism.prison.XmlAttributePrism;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+@ServiceProvider
+public class WriteBoxedByte extends WriteXmlAttribute {
+
+    private static final TypeName TN = TypeName.BYTE.box();
+
+    public WriteBoxedByte() {
+        super();
+    }
+
+    @Override
+    TypeName supportedTypeName() {
+        return TN;
+    }
+
+    @Override
+    void visitAttributeComponent(final AnalysedComponent analysedComponent, final XmlAttributePrism prism) {
+        final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
+        final boolean required = Boolean.TRUE.equals(prism.required());
+        final String attributeName = attributeName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
+
+        if (required) {
+            final String errMsg = XML_CANNOT_NULL_REQUIRED_ATTRIBUTE.formatted(analysedComponent.name(), attributeName);
+            methodBuilder.addStatement("$T.requireNonNull(val, $S)", OBJECTS, errMsg);
+        } else {
+            methodBuilder.beginControlFlow("if ($T.nonNull(val))", OBJECTS);
+        }
+
+        namespaceName.ifPresentOrElse(
+            namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, $T.valueOf(val.byteValue()))", namespace, attributeName, STRING),
+            () -> methodBuilder.addStatement("output.writeAttribute($S, $T.valueOf(val.byteValue()))", attributeName, STRING)
+        );
+
+        if (!required) {
+            methodBuilder.endControlFlow();
+        }
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimitiveByte.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WritePrimitiveByte.java
@@ -1,0 +1,36 @@
+package io.github.cbarlin.aru.impl.xml.utils.attribute;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.STRING;
+
+import java.util.Optional;
+
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.prism.prison.XmlAttributePrism;
+
+import io.avaje.spi.ServiceProvider;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+@ServiceProvider
+public class WritePrimitiveByte extends WriteXmlAttribute {
+
+    public WritePrimitiveByte() {
+        super();
+    }
+
+    @Override
+    TypeName supportedTypeName() {
+        return TypeName.BYTE;
+    }
+
+    @Override
+    void visitAttributeComponent(final AnalysedComponent analysedComponent, final XmlAttributePrism prism) {
+        final MethodSpec.Builder methodBuilder = createMethod(analysedComponent);
+        final String attributeName = attributeName(analysedComponent, prism);
+        final Optional<String> namespaceName = namespaceName(prism);
+        namespaceName.ifPresentOrElse(
+            namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, $T.valueOf(val))", namespace, attributeName, STRING),
+            () -> methodBuilder.addStatement("output.writeAttribute($S, $T.valueOf(val))", attributeName, STRING)
+        );
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteBoxedNumerics.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteBoxedNumerics.java
@@ -1,0 +1,114 @@
+package io.github.cbarlin.aru.impl.xml.utils.elements.noncollections;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.BIG_DECIMAL;
+import static io.github.cbarlin.aru.impl.Constants.Names.BIG_INTEGER;
+import static io.github.cbarlin.aru.impl.Constants.Names.OBJECTS;
+
+import java.util.Optional;
+import java.util.Set;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.types.AnalysedRecord;
+import io.github.cbarlin.aru.impl.Constants.Claims;
+import io.github.cbarlin.aru.impl.xml.XmlVisitor;
+import io.github.cbarlin.aru.prism.prison.XmlElementPrism;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+@ServiceProvider
+public class WriteBoxedNumerics extends XmlVisitor {
+
+    private static final Set<TypeName> BOXED_NUMERICS = Set.of(
+        TypeName.BYTE.box(),
+        TypeName.CHAR.box(),
+        TypeName.DOUBLE.box(),
+        TypeName.FLOAT.box(),
+        TypeName.INT.box(),
+        TypeName.LONG.box(),
+        TypeName.SHORT.box(),
+        BIG_DECIMAL,
+        BIG_INTEGER
+    );
+
+    public WriteBoxedNumerics() {
+        super(Claims.XML_WRITE_FIELD);
+    }
+
+    @Override
+    protected int innerSpecificity() {
+        return 1;
+    }
+
+    @Override
+    protected boolean innerIsApplicable(final AnalysedRecord analysedRecord) {
+        return true;
+    }
+
+    @Override
+    protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
+        final Optional<XmlElementPrism> optPrism = xmlElementPrism(analysedComponent);
+        if (optPrism.isPresent() && (!analysedComponent.isLoopable()) && BOXED_NUMERICS.contains(analysedComponent.unNestedPrimaryTypeName())) {
+            final XmlElementPrism prism = optPrism.get();
+            final String elementName = elementName(analysedComponent, prism);
+            final boolean required = Boolean.TRUE.equals(prism.required());
+            final Optional<String> defaultValue = defaultValue(prism);
+            final Optional<String> namespaceName = namespaceName(prism);
+            final MethodSpec.Builder methodBuilder = createMethod(analysedComponent, analysedComponent.unNestedPrimaryTypeName());
+            if (defaultValue.isPresent()) {
+                writeWithDefaultDefined(analysedComponent, elementName, defaultValue.get(), namespaceName, methodBuilder);
+            } else {
+                writeWithoutDefaultDefined(analysedComponent, elementName, required, namespaceName, methodBuilder);
+            }
+
+            return true;
+        }
+        return false;
+    }
+
+    private void writeWithoutDefaultDefined(
+            final AnalysedComponent analysedComponent, 
+            final String elementName, 
+            final boolean required,
+            final Optional<String> namespaceName, 
+            final MethodSpec.Builder methodBuilder
+    ) {
+        if (required) {
+            final String errMsg = XML_CANNOT_NULL_REQUIRED_ELEMENT.formatted(analysedComponent.name(), elementName);
+            methodBuilder.addStatement("$T.requireNonNull(val, $S)", OBJECTS, errMsg);
+        } else {
+            methodBuilder.beginControlFlow("if($T.nonNull(val))", OBJECTS);
+        }
+
+        namespaceName.ifPresentOrElse(
+            namespace -> methodBuilder.addStatement("output.writeStartElement($S, $S)", namespace, elementName),
+            () -> methodBuilder.addStatement("output.writeStartElement($S)", elementName)
+        );
+        methodBuilder.addStatement("output.writeCharacters(val.toString())")
+            .addStatement("output.writeEndElement()");
+      
+        if (!required) {
+            methodBuilder.endControlFlow();
+        }
+    }
+
+    private void writeWithDefaultDefined(
+            final AnalysedComponent analysedComponent, 
+            final String elementName,
+            final String writeAsDefaultValue, 
+            final Optional<String> namespaceName,
+            final MethodSpec.Builder methodBuilder
+    ) {
+        namespaceName.ifPresentOrElse(
+            namespace -> methodBuilder.addStatement("output.writeStartElement($S, $S)", namespace, elementName),
+            () -> methodBuilder.addStatement("output.writeStartElement($S)", elementName)
+        );
+        methodBuilder.beginControlFlow("if($T.nonNull(val))", OBJECTS)
+            .addStatement("output.writeCharacters(val.toString())")
+            .nextControlFlow("else");
+        logTrace(methodBuilder, "Supplied value for %s (element name %s) was null/blank, writing default of %s".formatted(analysedComponent.name(), elementName, writeAsDefaultValue));
+        methodBuilder.addStatement("output.writeCharacters($S)", writeAsDefaultValue)
+            .endControlFlow()
+            .addStatement("output.writeEndElement()");
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteOptionalPrimitive.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteOptionalPrimitive.java
@@ -23,7 +23,7 @@ public class WriteOptionalPrimitive extends XmlVisitor {
 
     @Override
     protected int innerSpecificity() {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WritePrimitiveNumerics.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WritePrimitiveNumerics.java
@@ -1,0 +1,66 @@
+package io.github.cbarlin.aru.impl.xml.utils.elements.noncollections;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.STRING;
+
+import java.util.Optional;
+import java.util.Set;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.APContext;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.types.AnalysedRecord;
+import io.github.cbarlin.aru.impl.Constants.Claims;
+import io.github.cbarlin.aru.impl.xml.XmlVisitor;
+import io.github.cbarlin.aru.prism.prison.XmlElementPrism;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+@ServiceProvider
+public class WritePrimitiveNumerics extends XmlVisitor {
+
+    private static final Set<TypeName> NUMERICS = Set.of(
+        TypeName.BYTE,
+        TypeName.CHAR,
+        TypeName.DOUBLE,
+        TypeName.FLOAT,
+        TypeName.INT,
+        TypeName.LONG,
+        TypeName.SHORT
+    );
+
+    public WritePrimitiveNumerics() {
+        super(Claims.XML_WRITE_FIELD);
+    }
+
+    @Override
+    protected int innerSpecificity() {
+        return 1;
+    }
+
+    @Override
+    protected boolean innerIsApplicable(final AnalysedRecord analysedRecord) {
+        return true;
+    }
+
+    @Override
+    protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
+        final Optional<XmlElementPrism> optPrism = xmlElementPrism(analysedComponent);
+        if (optPrism.isPresent() && (!analysedComponent.isLoopable()) && NUMERICS.contains(analysedComponent.unNestedPrimaryTypeName())) {
+            final XmlElementPrism prism = optPrism.get();
+            final String elementName = elementName(analysedComponent, prism);
+            final Optional<String> namespaceName = namespaceName(prism);
+            final MethodSpec.Builder methodBuilder = createMethod(analysedComponent, analysedComponent.unNestedPrimaryTypeName());
+
+            defaultValue(prism).ifPresent(ignored -> APContext.messager().printNote("Primitives will never use their defaults - ignoring requested default", analysedComponent.element()));
+
+            namespaceName.ifPresentOrElse(
+                namespace -> methodBuilder.addStatement("output.writeStartElement($S, $S)", namespace, elementName),
+                () -> methodBuilder.addStatement("output.writeStartElement($S)", elementName)
+            );
+            methodBuilder.addStatement("output.writeCharacters($T.valueOf(val))", STRING)
+                .addStatement("output.writeEndElement()");
+            return true;
+        }
+        return false;
+    }
+}

--- a/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NumericsBag.java
+++ b/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NumericsBag.java
@@ -1,0 +1,170 @@
+package io.github.cbarlin.aru.tests.c_odd_types;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
+import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.LoggingGeneration;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+@AdvancedRecordUtils(
+    xmlable = true,
+    wither = true,
+    merger = true,
+    logGeneration = LoggingGeneration.SLF4J_GENERATED_UTIL_INTERFACE,
+    createAllInterface = true
+)
+@XmlRootElement(
+    name = "NumericsTest",
+    namespace = "nx://Numerics"
+)
+// Reminder: Default values are written literally - they are not converted at all
+public record NumericsBag(
+    // Bytes
+    @XmlAttribute(name = "primitiveByteAttribute")
+    byte primitiveByteAttribute,
+    @XmlAttribute(name = "boxedByteAttribute")
+    Byte boxedByteAttribute,
+    @XmlAttribute(name = "boxedByteAttributeRequired", required = true)
+    Byte boxedByteAttributeRequired,
+    @XmlElement(name = "primitiveByteElement", required = true)
+    byte primitiveByteElement,
+    @XmlElement(name = "boxedByteElement", required = true)
+    Byte boxedByteElement,
+    @XmlElement(name = "boxedByteElementRequired", required = true)
+    Byte boxedByteElementRequired,
+    @XmlElement(name = "boxedByteElementDefault", defaultValue = "1")
+    Byte boxedByteElementDefault,
+    @XmlElement(name = "boxedByteElementRequiredDefault", required = true, defaultValue = "1")
+    Byte boxedByteElementRequiredDefault,
+    // Char
+    @XmlAttribute(name = "primitiveCharAttribute")
+    char primitiveCharAttribute,
+    @XmlAttribute(name = "boxedCharAttribute")
+    Character boxedCharAttribute,
+    @XmlAttribute(name = "boxedCharAttributeRequired", required = true)
+    Character boxedCharAttributeRequired,
+    @XmlElement(name = "primitiveCharElement", required = true)
+    char primitiveCharElement,
+    @XmlElement(name = "boxedCharElement", required = true)
+    Character boxedCharElement,
+    @XmlElement(name = "boxedCharElementRequired", required = true)
+    Character boxedCharElementRequired,
+    @XmlElement(name = "boxedCharElementDefault", defaultValue = "1")
+    Character boxedCharElementDefault,
+    @XmlElement(name = "boxedCharElementRequiredDefault", required = true, defaultValue = "1")
+    Character boxedCharElementRequiredDefault,
+    // Doubles
+    @XmlAttribute(name = "primitiveDoubleAttribute")
+    double primitiveDoubleAttribute,
+    @XmlAttribute(name = "boxedDoubleAttribute")
+    Double boxedDoubleAttribute,
+    @XmlAttribute(name = "boxedDoubleAttributeRequired", required = true)
+    Double boxedDoubleAttributeRequired,
+    @XmlElement(name = "primitiveDoubleElement", required = true)
+    double primitiveDoubleElement,
+    @XmlElement(name = "boxedDoubleElement", required = true)
+    Double boxedDoubleElement,
+    @XmlElement(name = "boxedDoubleElementRequired", required = true)
+    Double boxedDoubleElementRequired,
+    @XmlElement(name = "boxedDoubleElementDefault", defaultValue = "1")
+    Double boxedDoubleElementDefault,
+    @XmlElement(name = "boxedDoubleElementRequiredDefault", required = true, defaultValue = "1")
+    Double boxedDoubleElementRequiredDefault,
+    // Ints
+    @XmlAttribute(name = "primitiveIntAttribute")
+    int primitiveIntAttribute,
+    @XmlAttribute(name = "boxedIntAttribute")
+    Integer boxedIntAttribute,
+    @XmlAttribute(name = "boxedIntAttributeRequired", required = true)
+    Integer boxedIntAttributeRequired,
+    @XmlElement(name = "primitiveIntElement", required = true)
+    int primitiveIntElement,
+    @XmlElement(name = "boxedIntElement", required = true)
+    Integer boxedIntElement,
+    @XmlElement(name = "boxedIntElementRequired", required = true)
+    Integer boxedIntElementRequired,
+    @XmlElement(name = "boxedIntElementDefault", defaultValue = "1")
+    Integer boxedIntElementDefault,
+    @XmlElement(name = "boxedIntElementRequiredDefault", required = true, defaultValue = "1")
+    Integer boxedIntElementRequiredDefault,
+    // Longs
+    @XmlAttribute(name = "primitiveLongAttribute")
+    long primitiveLongAttribute,
+    @XmlAttribute(name = "boxedLongAttribute")
+    Long boxedLongAttribute,
+    @XmlAttribute(name = "boxedLongAttributeRequired", required = true)
+    Long boxedLongAttributeRequired,
+    @XmlElement(name = "primitiveLongElement", required = true)
+    long primitiveLongElement,
+    @XmlElement(name = "boxedLongElement", required = true)
+    Long boxedLongElement,
+    @XmlElement(name = "boxedLongElementRequired", required = true)
+    Long boxedLongElementRequired,
+    @XmlElement(name = "boxedLongElementDefault", defaultValue = "1")
+    Long boxedLongElementDefault,
+    @XmlElement(name = "boxedLongElementRequiredDefault", required = true, defaultValue = "1")
+    Long boxedLongElementRequiredDefault,
+    // Floats
+    @XmlAttribute(name = "primitiveFloatAttribute")
+    float primitiveFloatAttribute,
+    @XmlAttribute(name = "boxedFloatAttribute")
+    Float boxedFloatAttribute,
+    @XmlAttribute(name = "boxedFloatAttributeRequired", required = true)
+    Float boxedFloatAttributeRequired,
+    @XmlElement(name = "primitiveFloatElement", required = true)
+    float primitiveFloatElement,
+    @XmlElement(name = "boxedFloatElement", required = true)
+    Float boxedFloatElement,
+    @XmlElement(name = "boxedFloatElementRequired", required = true)
+    Float boxedFloatElementRequired,
+    @XmlElement(name = "boxedFloatElementDefault", defaultValue = "1")
+    Float boxedFloatElementDefault,
+    @XmlElement(name = "boxedFloatElementRequiredDefault", required = true, defaultValue = "1")
+    Float boxedFloatElementRequiredDefault,
+    // Shorts
+    @XmlAttribute(name = "primitiveShortAttribute")
+    short primitiveShortAttribute,
+    @XmlAttribute(name = "boxedShortAttribute")
+    Short boxedShortAttribute,
+    @XmlAttribute(name = "boxedShortAttributeRequired", required = true)
+    Short boxedShortAttributeRequired,
+    @XmlElement(name = "primitiveShortElement", required = true)
+    short primitiveShortElement,
+    @XmlElement(name = "boxedShortElement", required = true)
+    Short boxedShortElement,
+    @XmlElement(name = "boxedShortElementRequired", required = true)
+    Short boxedShortElementRequired,
+    @XmlElement(name = "boxedShortElementDefault", defaultValue = "1")
+    Short boxedShortElementDefault,
+    @XmlElement(name = "boxedShortElementRequiredDefault", required = true, defaultValue = "1")
+    Short boxedShortElementRequiredDefault,
+    // BigInteger
+    @XmlAttribute(name = "bigIntegerAttribute")
+    BigInteger bigIntegerAttribute,
+    @XmlAttribute(name = "bigIntegerAttributeRequired", required = true)
+    BigInteger bigIntegerAttributeRequired,
+    @XmlElement(name = "bigIntegerElement", required = true)
+    BigInteger bigIntegerElement,
+    @XmlElement(name = "bigIntegerElementRequired", required = true)
+    BigInteger bigIntegerElementRequired,
+    @XmlElement(name = "bigIntegerElementDefault", defaultValue = "1")
+    BigInteger bigIntegerElementDefault,
+    @XmlElement(name = "bigIntegerElementRequiredDefault", required = true, defaultValue = "1")
+    BigInteger bigIntegerElementRequiredDefault,
+    // BigDecimal
+    @XmlAttribute(name = "bigDecimalAttribute")
+    BigDecimal bigDecimalAttribute,
+    @XmlAttribute(name = "bigDecimalAttributeRequired", required = true)
+    BigDecimal bigDecimalAttributeRequired,
+    @XmlElement(name = "bigDecimalElement", required = true)
+    BigDecimal bigDecimalElement,
+    @XmlElement(name = "bigDecimalElementRequired", required = true)
+    BigDecimal bigDecimalElementRequired,
+    @XmlElement(name = "bigDecimalElementDefault", defaultValue = "1")
+    BigDecimal bigDecimalElementDefault,
+    @XmlElement(name = "bigDecimalElementRequiredDefault", required = true, defaultValue = "1")
+    BigDecimal bigDecimalElementRequiredDefault
+) implements NumericsBagUtils.All {}

--- a/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/NumericsTest.java
+++ b/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/NumericsTest.java
@@ -1,0 +1,146 @@
+package io.github.cbarlin.aru.tests.c_odd_types;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.cbarlin.aru.tests.xml_util.ConvertToXml;
+
+class NumericsTest {
+
+    private static final byte PRIMITIVE_BYTE_VALUE = 69;
+    private static final Byte BOXED_BYTE_VALUE = Byte.valueOf(PRIMITIVE_BYTE_VALUE);
+
+    private static final double PRIMITIVE_DOUBLE_VALUE = 69d;
+    private static final Double BOXED_DOUBLE_VALUE = Double.valueOf(PRIMITIVE_DOUBLE_VALUE);
+
+    private static final int PRIMITIVE_INT_VALUE = 69;
+    private static final Integer BOXED_INT_VALUE = Integer.valueOf(PRIMITIVE_INT_VALUE);
+
+    private static final char PRIMITIVE_CHAR_VALUE = 69;
+    private static final Character BOXED_CHAR_VALUE = Character.valueOf(PRIMITIVE_CHAR_VALUE);
+
+    private static final long PRIMITIVE_LONG_VALUE = 69;
+    private static final Long BOXED_LONG_VALUE = Long.valueOf(PRIMITIVE_LONG_VALUE);
+
+    private static final float PRIMITIVE_FLOAT_VALUE = 69;
+    private static final Float BOXED_FLOAT_VALUE = Float.valueOf(PRIMITIVE_FLOAT_VALUE);
+
+    private static final short PRIMITIVE_SHORT_VALUE = 69;
+    private static final Short BOXED_SHORT_VALUE = Short.valueOf(PRIMITIVE_SHORT_VALUE);
+
+    private static final BigInteger BIG_INTEGER = BigInteger.TEN;
+    private static final BigDecimal BIG_DECIMAL = BigDecimal.TEN;
+
+    NumericsBag buildNoDefaults() {
+        return NumericsBagUtils.builder()
+            // byte
+            .primitiveByteAttribute(PRIMITIVE_BYTE_VALUE)
+            .primitiveByteElement(PRIMITIVE_BYTE_VALUE)
+            .boxedByteAttribute(BOXED_BYTE_VALUE)
+            .boxedByteAttributeRequired(BOXED_BYTE_VALUE)
+            .boxedByteElement(BOXED_BYTE_VALUE)
+            .boxedByteElementRequired(BOXED_BYTE_VALUE)
+            // char
+            .primitiveCharAttribute(PRIMITIVE_CHAR_VALUE)
+            .primitiveCharElement(PRIMITIVE_CHAR_VALUE)
+            .boxedCharAttribute(BOXED_CHAR_VALUE)
+            .boxedCharAttributeRequired(BOXED_CHAR_VALUE)
+            .boxedCharElement(BOXED_CHAR_VALUE)
+            .boxedCharElementRequired(BOXED_CHAR_VALUE)
+            // double
+            .primitiveDoubleAttribute(PRIMITIVE_DOUBLE_VALUE)
+            .primitiveDoubleElement(PRIMITIVE_DOUBLE_VALUE)
+            .boxedDoubleAttribute(BOXED_DOUBLE_VALUE)
+            .boxedDoubleAttributeRequired(BOXED_DOUBLE_VALUE)
+            .boxedDoubleElement(BOXED_DOUBLE_VALUE)
+            .boxedDoubleElementRequired(BOXED_DOUBLE_VALUE)
+            // int
+            .primitiveIntAttribute(PRIMITIVE_INT_VALUE)
+            .primitiveIntElement(PRIMITIVE_INT_VALUE)
+            .boxedIntAttribute(BOXED_INT_VALUE)
+            .boxedIntAttributeRequired(BOXED_INT_VALUE)
+            .boxedIntElement(BOXED_INT_VALUE)
+            .boxedIntElementRequired(BOXED_INT_VALUE)
+            // long
+            .primitiveLongAttribute(PRIMITIVE_LONG_VALUE)
+            .primitiveLongElement(PRIMITIVE_LONG_VALUE)
+            .boxedLongAttribute(BOXED_LONG_VALUE)
+            .boxedLongAttributeRequired(BOXED_LONG_VALUE)
+            .boxedLongElement(BOXED_LONG_VALUE)
+            .boxedLongElementRequired(BOXED_LONG_VALUE)
+            // float
+            .primitiveFloatAttribute(PRIMITIVE_FLOAT_VALUE)
+            .primitiveFloatElement(PRIMITIVE_FLOAT_VALUE)
+            .boxedFloatAttribute(BOXED_FLOAT_VALUE)
+            .boxedFloatAttributeRequired(BOXED_FLOAT_VALUE)
+            .boxedFloatElement(BOXED_FLOAT_VALUE)
+            .boxedFloatElementRequired(BOXED_FLOAT_VALUE)
+            // short
+            .primitiveShortAttribute(PRIMITIVE_SHORT_VALUE)
+            .primitiveShortElement(PRIMITIVE_SHORT_VALUE)
+            .boxedShortAttribute(BOXED_SHORT_VALUE)
+            .boxedShortAttributeRequired(BOXED_SHORT_VALUE)
+            .boxedShortElement(BOXED_SHORT_VALUE)
+            .boxedShortElementRequired(BOXED_SHORT_VALUE)
+            // BigInteger
+            .bigIntegerAttribute(BIG_INTEGER)
+            .bigIntegerAttributeRequired(BIG_INTEGER)
+            .bigIntegerElement(BIG_INTEGER)
+            .bigIntegerElementRequired(BIG_INTEGER)
+            // BigDecimal
+            .bigDecimalAttribute(BIG_DECIMAL)
+            .bigDecimalAttributeRequired(BIG_DECIMAL)
+            .bigDecimalElement(BIG_DECIMAL)
+            .bigDecimalElementRequired(BIG_DECIMAL)
+
+            .build();
+    }
+
+    NumericsBag buildWithDefaults() {
+        return buildNoDefaults().with()
+            // byte
+            .boxedByteElementDefault(BOXED_BYTE_VALUE)
+            .boxedByteElementRequiredDefault(BOXED_BYTE_VALUE)
+            // char
+            .boxedCharElementDefault(BOXED_CHAR_VALUE)
+            .boxedCharElementRequiredDefault(BOXED_CHAR_VALUE)
+            // double
+            .boxedDoubleElementDefault(BOXED_DOUBLE_VALUE)
+            .boxedDoubleElementRequiredDefault(BOXED_DOUBLE_VALUE)
+            // int
+            .boxedIntElementDefault(BOXED_INT_VALUE)
+            .boxedIntElementRequiredDefault(BOXED_INT_VALUE)
+            // long
+            .boxedLongElementDefault(BOXED_LONG_VALUE)
+            .boxedLongElementRequiredDefault(BOXED_LONG_VALUE)
+            // float
+            .boxedFloatElementDefault(BOXED_FLOAT_VALUE)
+            .boxedFloatElementRequiredDefault(BOXED_FLOAT_VALUE)
+            // short
+            .boxedShortElementDefault(BOXED_SHORT_VALUE)
+            .boxedShortElementRequiredDefault(BOXED_SHORT_VALUE)
+            // BigInteger
+            .bigIntegerElementDefault(BIG_INTEGER)
+            .bigIntegerElementRequiredDefault(BIG_INTEGER)
+            // BigDecimal
+            .bigDecimalElementDefault(BIG_DECIMAL)
+            .bigDecimalElementRequiredDefault(BIG_DECIMAL)
+
+            .build();
+    }
+
+    @Test
+    void xmlNoDefaults() {
+        ConvertToXml.compareXml(out -> assertDoesNotThrow(() -> buildNoDefaults().writeSelfTo(out)), "expected_numerics_no_defaults.xml");
+    }
+
+    @Test
+    void xmlWithDefaults() {
+        ConvertToXml.compareXml(out -> assertDoesNotThrow(() -> buildWithDefaults().writeSelfTo(out)), "expected_numerics_with_defaults.xml");
+    }
+
+}

--- a/utils-tests/c_odd_types/src/test/resources/expected_numerics_no_defaults.xml
+++ b/utils-tests/c_odd_types/src/test/resources/expected_numerics_no_defaults.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<NumericsTest
+    xmlns="nx://Numerics"
+
+    primitiveByteAttribute="69"
+    boxedByteAttribute="69"
+    boxedByteAttributeRequired="69"
+
+    primitiveDoubleAttribute="69.0"
+    boxedDoubleAttribute="69.0"
+    boxedDoubleAttributeRequired="69.0"
+
+    primitiveCharAttribute="E"
+    boxedCharAttribute="E"
+    boxedCharAttributeRequired="E"
+
+    primitiveIntAttribute="69"
+    boxedIntAttribute="69"
+    boxedIntAttributeRequired="69"
+
+    primitiveLongAttribute="69"
+    boxedLongAttribute="69"
+    boxedLongAttributeRequired="69"
+
+    primitiveFloatAttribute="69.0"
+    boxedFloatAttribute="69.0"
+    boxedFloatAttributeRequired="69.0"
+
+    primitiveShortAttribute="69"
+    boxedShortAttribute="69"
+    boxedShortAttributeRequired="69"
+
+    bigIntegerAttribute="10"
+    bigIntegerAttributeRequired="10"
+
+    bigDecimalAttribute="10"
+    bigDecimalAttributeRequired="10"
+>
+    <!-- Bytes -->
+    <primitiveByteElement>69</primitiveByteElement>
+    <boxedByteElement>69</boxedByteElement>
+    <boxedByteElementRequired>69</boxedByteElementRequired>
+    <boxedByteElementDefault>1</boxedByteElementDefault>
+    <boxedByteElementRequiredDefault>1</boxedByteElementRequiredDefault>
+    <!-- Chars -->
+    <primitiveCharElement>E</primitiveCharElement>
+    <boxedCharElement>E</boxedCharElement>
+    <boxedCharElementRequired>E</boxedCharElementRequired>
+    <boxedCharElementDefault>1</boxedCharElementDefault>
+    <boxedCharElementRequiredDefault>1</boxedCharElementRequiredDefault>
+    <!-- Doubles -->
+    <primitiveDoubleElement>69.0</primitiveDoubleElement>
+    <boxedDoubleElement>69.0</boxedDoubleElement>
+    <boxedDoubleElementRequired>69.0</boxedDoubleElementRequired>
+    <boxedDoubleElementDefault>1</boxedDoubleElementDefault>
+    <boxedDoubleElementRequiredDefault>1</boxedDoubleElementRequiredDefault>
+    <!-- Ints -->
+    <primitiveIntElement>69</primitiveIntElement>
+    <boxedIntElement>69</boxedIntElement>
+    <boxedIntElementRequired>69</boxedIntElementRequired>
+    <boxedIntElementDefault>1</boxedIntElementDefault>
+    <boxedIntElementRequiredDefault>1</boxedIntElementRequiredDefault>
+    <!-- Longs -->
+    <primitiveLongElement>69</primitiveLongElement>
+    <boxedLongElement>69</boxedLongElement>
+    <boxedLongElementRequired>69</boxedLongElementRequired>
+    <boxedLongElementDefault>1</boxedLongElementDefault>
+    <boxedLongElementRequiredDefault>1</boxedLongElementRequiredDefault>
+    <!-- Floats -->
+    <primitiveFloatElement>69.0</primitiveFloatElement>
+    <boxedFloatElement>69.0</boxedFloatElement>
+    <boxedFloatElementRequired>69.0</boxedFloatElementRequired>
+    <boxedFloatElementDefault>1</boxedFloatElementDefault>
+    <boxedFloatElementRequiredDefault>1</boxedFloatElementRequiredDefault>
+    <!-- Shorts -->
+    <primitiveShortElement>69</primitiveShortElement>
+    <boxedShortElement>69</boxedShortElement>
+    <boxedShortElementRequired>69</boxedShortElementRequired>
+    <boxedShortElementDefault>1</boxedShortElementDefault>
+    <boxedShortElementRequiredDefault>1</boxedShortElementRequiredDefault>
+
+    <!-- Bigs -->
+    <bigIntegerElement>10</bigIntegerElement>
+    <bigIntegerElementRequired>10</bigIntegerElementRequired>
+    <bigIntegerElementDefault>1</bigIntegerElementDefault>
+    <bigIntegerElementRequiredDefault>1</bigIntegerElementRequiredDefault>
+
+    <bigDecimalElement>10</bigDecimalElement>
+    <bigDecimalElementRequired>10</bigDecimalElementRequired>
+    <bigDecimalElementDefault>1</bigDecimalElementDefault>
+    <bigDecimalElementRequiredDefault>1</bigDecimalElementRequiredDefault>
+    
+
+</NumericsTest>

--- a/utils-tests/c_odd_types/src/test/resources/expected_numerics_with_defaults.xml
+++ b/utils-tests/c_odd_types/src/test/resources/expected_numerics_with_defaults.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0"?>
+<NumericsTest
+
+    xmlns="nx://Numerics"
+
+    primitiveByteAttribute="69"
+    boxedByteAttribute="69"
+    boxedByteAttributeRequired="69"
+
+    primitiveDoubleAttribute="69.0"
+    boxedDoubleAttribute="69.0"
+    boxedDoubleAttributeRequired="69.0"
+
+    primitiveCharAttribute="E"
+    boxedCharAttribute="E"
+    boxedCharAttributeRequired="E"
+
+    primitiveIntAttribute="69"
+    boxedIntAttribute="69"
+    boxedIntAttributeRequired="69"
+
+    primitiveLongAttribute="69"
+    boxedLongAttribute="69"
+    boxedLongAttributeRequired="69"
+
+    primitiveFloatAttribute="69.0"
+    boxedFloatAttribute="69.0"
+    boxedFloatAttributeRequired="69.0"
+
+    primitiveShortAttribute="69"
+    boxedShortAttribute="69"
+    boxedShortAttributeRequired="69"
+
+    bigIntegerAttribute="10"
+    bigIntegerAttributeRequired="10"
+
+    bigDecimalAttribute="10"
+    bigDecimalAttributeRequired="10"
+
+>
+    <!-- Bytes -->
+    <primitiveByteElement>69</primitiveByteElement>
+    <boxedByteElement>69</boxedByteElement>
+    <boxedByteElementRequired>69</boxedByteElementRequired>
+    <boxedByteElementDefault>69</boxedByteElementDefault>
+    <boxedByteElementRequiredDefault>69</boxedByteElementRequiredDefault>
+    <!-- Chars -->
+    <primitiveCharElement>E</primitiveCharElement>
+    <boxedCharElement>E</boxedCharElement>
+    <boxedCharElementRequired>E</boxedCharElementRequired>
+    <boxedCharElementDefault>E</boxedCharElementDefault>
+    <boxedCharElementRequiredDefault>E</boxedCharElementRequiredDefault>
+    <!-- Doubles -->
+    <primitiveDoubleElement>69.0</primitiveDoubleElement>
+    <boxedDoubleElement>69.0</boxedDoubleElement>
+    <boxedDoubleElementRequired>69.0</boxedDoubleElementRequired>
+    <boxedDoubleElementDefault>69.0</boxedDoubleElementDefault>
+    <boxedDoubleElementRequiredDefault>69.0</boxedDoubleElementRequiredDefault>
+    <!-- Ints -->
+    <primitiveIntElement>69</primitiveIntElement>
+    <boxedIntElement>69</boxedIntElement>
+    <boxedIntElementRequired>69</boxedIntElementRequired>
+    <boxedIntElementDefault>69</boxedIntElementDefault>
+    <boxedIntElementRequiredDefault>69</boxedIntElementRequiredDefault>
+    <!-- Longs -->
+    <primitiveLongElement>69</primitiveLongElement>
+    <boxedLongElement>69</boxedLongElement>
+    <boxedLongElementRequired>69</boxedLongElementRequired>
+    <boxedLongElementDefault>69</boxedLongElementDefault>
+    <boxedLongElementRequiredDefault>69</boxedLongElementRequiredDefault>
+    <!-- Floats -->
+    <primitiveFloatElement>69.0</primitiveFloatElement>
+    <boxedFloatElement>69.0</boxedFloatElement>
+    <boxedFloatElementRequired>69.0</boxedFloatElementRequired>
+    <boxedFloatElementDefault>69.0</boxedFloatElementDefault>
+    <boxedFloatElementRequiredDefault>69.0</boxedFloatElementRequiredDefault>
+    <!-- Shorts -->
+    <primitiveShortElement>69</primitiveShortElement>
+    <boxedShortElement>69</boxedShortElement>
+    <boxedShortElementRequired>69</boxedShortElementRequired>
+    <boxedShortElementDefault>69</boxedShortElementDefault>
+    <boxedShortElementRequiredDefault>69</boxedShortElementRequiredDefault>
+
+    <!-- Bigs -->
+    <bigIntegerElement>10</bigIntegerElement>
+    <bigIntegerElementRequired>10</bigIntegerElementRequired>
+    <bigIntegerElementDefault>10</bigIntegerElementDefault>
+    <bigIntegerElementRequiredDefault>10</bigIntegerElementRequiredDefault>
+
+    <bigDecimalElement>10</bigDecimalElement>
+    <bigDecimalElementRequired>10</bigDecimalElementRequired>
+    <bigDecimalElementDefault>10</bigDecimalElementDefault>
+    <bigDecimalElementRequiredDefault>10</bigDecimalElementRequiredDefault>
+
+</NumericsTest>


### PR DESCRIPTION
Fixes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for XML serialization of all Java numeric types, including primitive, boxed, BigInteger, and BigDecimal, as both attributes and elements.
  - Introduced comprehensive handling for required, optional, and defaulted numeric XML fields.
- **Tests**
  - Added extensive test coverage for numeric XML serialization scenarios, including new test classes and expected XML output resources.
- **Bug Fixes**
  - Improved handling of specificity for optional primitive numeric elements to ensure correct XML writing behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->