### PR TITLE
Add more XML Element date serialisers

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,7 +41,9 @@ reviews:
       instructions: |
         This folder, including "main" files, are all for the purpose of testing. This is because an annotation processor can only really be tested by applying it to a build
 
-        Coding standards can be relaxed a little here, as the code isn't published and isn't used by anyone except for tests
+        Coding standards can be relaxed a little here, as the code isn't published and isn't used by anyone except for tests. 
+        
+        We also don't have to be "formal" with the content - using references for test content is fine.
     - path: 'advanced-record-utils-annotations/**/*.java'
       instructions: |
         This is the user-facing part of the library. It must be well-documented

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,6 +17,9 @@ knowledge_base:
     scope: 'local'
 reviews:
   profile: 'assertive'
+  finishing_touches:
+    docstrings:
+      enabled: false
   auto_review:
     base_branches:
       - 'main'

--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtilsGenerated.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtilsGenerated.java
@@ -35,8 +35,8 @@ public @interface AdvancedRecordUtilsGenerated {
 
     public @interface Version {
         public static final int MAJOR_VERSION = 0;
-        public static final int MINOR_VERSION = 1;
-        public static final int PATCH_VERSION = 6;
+        public static final int MINOR_VERSION = 2;
+        public static final int PATCH_VERSION = 2;
 
         int major() default MAJOR_VERSION;
 

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteLocalDateTime.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/attribute/WriteLocalDateTime.java
@@ -43,8 +43,8 @@ public class WriteLocalDateTime extends WriteXmlAttribute {
         }
         logTrace(methodBuilder, "Converting value to UTC - assuming that LocalDateTime has the System Default time zone");
         namespaceName.ifPresentOrElse(
-            namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, val.atZone($T.systemDefault()).toOffsetDateTime().atZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", namespace, attributeName, ZONE_ID, ZONE_OFFSET, DATE_TIME_FORMATTER),
-            () -> methodBuilder.addStatement("output.writeAttribute($S, val.atZone($T.systemDefault()).toOffsetDateTime().atZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", attributeName, ZONE_ID, ZONE_OFFSET, DATE_TIME_FORMATTER)
+            namespace -> methodBuilder.addStatement("output.writeAttribute($S, $S, val.atZone($T.systemDefault()).withZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", namespace, attributeName, ZONE_ID, ZONE_OFFSET, DATE_TIME_FORMATTER),
+            () -> methodBuilder.addStatement("output.writeAttribute($S, val.atZone($T.systemDefault()).withZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", attributeName, ZONE_ID, ZONE_OFFSET, DATE_TIME_FORMATTER)
         );
 
         if (!required) {

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteLocalDatetime.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteLocalDatetime.java
@@ -19,7 +19,7 @@ import io.micronaut.sourcegen.javapoet.MethodSpec;
 @ServiceProvider
 public class WriteLocalDatetime extends XmlVisitor {
 
-    private static final String CHK_NULL = "if ($T.nonNull(val))";
+    private static final String CHK_NON_NULL = "if ($T.nonNull(val))";
 
     public WriteLocalDatetime() {
         super(Claims.XML_WRITE_FIELD);
@@ -68,7 +68,7 @@ public class WriteLocalDatetime extends XmlVisitor {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ELEMENT.formatted(analysedComponent.name(), elementName);
             methodBuilder.addStatement("$T.requireNonNull(val, $S)", OBJECTS, errMsg);
         } else {
-            methodBuilder.beginControlFlow(CHK_NULL, OBJECTS);
+            methodBuilder.beginControlFlow(CHK_NON_NULL, OBJECTS);
         }
       
         namespaceName.ifPresentOrElse(
@@ -94,7 +94,7 @@ public class WriteLocalDatetime extends XmlVisitor {
             namespace -> methodBuilder.addStatement("output.writeStartElement($S, $S)", namespace, elementName),
             () -> methodBuilder.addStatement("output.writeStartElement($S)", elementName)
         );
-        methodBuilder.beginControlFlow(CHK_NULL, OBJECTS)
+        methodBuilder.beginControlFlow(CHK_NON_NULL, OBJECTS)
             .addStatement("output.writeCharacters(val.atZone($T.systemDefault()).withZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", ZONE_ID, ZONE_OFFSET, DATE_TIME_FORMATTER)
             .nextControlFlow("else");
         logTrace(methodBuilder, "Supplied value for %s (element name %s) was null/blank, writing default of %s".formatted(analysedComponent.name(), elementName, writeAsDefaultValue));

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteLocalDatetime.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteLocalDatetime.java
@@ -2,7 +2,8 @@ package io.github.cbarlin.aru.impl.xml.utils.elements.noncollections;
 
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
 import static io.github.cbarlin.aru.impl.Constants.Names.DATE_TIME_FORMATTER;
-import static io.github.cbarlin.aru.impl.Constants.Names.OFFSET_DATE_TIME;
+import static io.github.cbarlin.aru.impl.Constants.Names.LOCAL_DATE_TIME;
+import static io.github.cbarlin.aru.impl.Constants.Names.ZONE_ID;
 import static io.github.cbarlin.aru.impl.Constants.Names.ZONE_OFFSET;
 
 import java.util.Optional;
@@ -16,11 +17,11 @@ import io.github.cbarlin.aru.prism.prison.XmlElementPrism;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
 
 @ServiceProvider
-public class WriteOffsetDatetime extends XmlVisitor {
+public class WriteLocalDatetime extends XmlVisitor {
 
     private static final String CHK_NULL = "if ($T.nonNull(val))";
 
-    public WriteOffsetDatetime() {
+    public WriteLocalDatetime() {
         super(Claims.XML_WRITE_FIELD);
     }
 
@@ -37,7 +38,7 @@ public class WriteOffsetDatetime extends XmlVisitor {
     @Override
     protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
         final Optional<XmlElementPrism> optPrism = xmlElementPrism(analysedComponent);
-        if (optPrism.isPresent() && OFFSET_DATE_TIME.equals(analysedComponent.typeName())) {
+        if (optPrism.isPresent() && LOCAL_DATE_TIME.equals(analysedComponent.typeName())) {
             // Nice!
             final XmlElementPrism prism = optPrism.get();
             final String elementName = elementName(analysedComponent, prism);
@@ -74,7 +75,7 @@ public class WriteOffsetDatetime extends XmlVisitor {
             namespace -> methodBuilder.addStatement("output.writeStartElement($S, $S)", namespace, elementName),
             () -> methodBuilder.addStatement("output.writeStartElement($S)", elementName)
         );
-        methodBuilder.addStatement("output.writeCharacters(val.atZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", ZONE_OFFSET, DATE_TIME_FORMATTER)
+        methodBuilder.addStatement("output.writeCharacters(val.atZone($T.systemDefault()).withZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", ZONE_ID, ZONE_OFFSET, DATE_TIME_FORMATTER)
             .addStatement("output.writeEndElement()");
       
         if (!required) {
@@ -94,7 +95,7 @@ public class WriteOffsetDatetime extends XmlVisitor {
             () -> methodBuilder.addStatement("output.writeStartElement($S)", elementName)
         );
         methodBuilder.beginControlFlow(CHK_NULL, OBJECTS)
-            .addStatement("output.writeCharacters(val.atZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", ZONE_OFFSET, DATE_TIME_FORMATTER)
+            .addStatement("output.writeCharacters(val.atZone($T.systemDefault()).withZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", ZONE_ID, ZONE_OFFSET, DATE_TIME_FORMATTER)
             .nextControlFlow("else");
         logTrace(methodBuilder, "Supplied value for %s (element name %s) was null/blank, writing default of %s".formatted(analysedComponent.name(), elementName, writeAsDefaultValue));
         methodBuilder.addStatement("output.writeCharacters($S)", writeAsDefaultValue)

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteOffsetDatetime.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteOffsetDatetime.java
@@ -18,7 +18,7 @@ import io.micronaut.sourcegen.javapoet.MethodSpec;
 @ServiceProvider
 public class WriteOffsetDatetime extends XmlVisitor {
 
-    private static final String CHK_NULL = "if ($T.nonNull(val))";
+    private static final String CHK_NON_NULL = "if ($T.nonNull(val))";
 
     public WriteOffsetDatetime() {
         super(Claims.XML_WRITE_FIELD);
@@ -67,7 +67,7 @@ public class WriteOffsetDatetime extends XmlVisitor {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ELEMENT.formatted(analysedComponent.name(), elementName);
             methodBuilder.addStatement("$T.requireNonNull(val, $S)", OBJECTS, errMsg);
         } else {
-            methodBuilder.beginControlFlow(CHK_NULL, OBJECTS);
+            methodBuilder.beginControlFlow(CHK_NON_NULL, OBJECTS);
         }
       
         namespaceName.ifPresentOrElse(
@@ -93,7 +93,7 @@ public class WriteOffsetDatetime extends XmlVisitor {
             namespace -> methodBuilder.addStatement("output.writeStartElement($S, $S)", namespace, elementName),
             () -> methodBuilder.addStatement("output.writeStartElement($S)", elementName)
         );
-        methodBuilder.beginControlFlow(CHK_NULL, OBJECTS)
+        methodBuilder.beginControlFlow(CHK_NON_NULL, OBJECTS)
             .addStatement("output.writeCharacters(val.atZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", ZONE_OFFSET, DATE_TIME_FORMATTER)
             .nextControlFlow("else");
         logTrace(methodBuilder, "Supplied value for %s (element name %s) was null/blank, writing default of %s".formatted(analysedComponent.name(), elementName, writeAsDefaultValue));

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteZonedDatetime.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteZonedDatetime.java
@@ -18,7 +18,7 @@ import io.micronaut.sourcegen.javapoet.MethodSpec;
 @ServiceProvider
 public class WriteZonedDatetime extends XmlVisitor {
 
-    private static final String CHK_NULL = "if ($T.nonNull(val))";
+    private static final String CHK_NON_NULL = "if ($T.nonNull(val))";
 
     public WriteZonedDatetime() {
         super(Claims.XML_WRITE_FIELD);
@@ -67,7 +67,7 @@ public class WriteZonedDatetime extends XmlVisitor {
             final String errMsg = XML_CANNOT_NULL_REQUIRED_ELEMENT.formatted(analysedComponent.name(), elementName);
             methodBuilder.addStatement("$T.requireNonNull(val, $S)", OBJECTS, errMsg);
         } else {
-            methodBuilder.beginControlFlow(CHK_NULL, OBJECTS);
+            methodBuilder.beginControlFlow(CHK_NON_NULL, OBJECTS);
         }
       
         namespaceName.ifPresentOrElse(
@@ -93,7 +93,7 @@ public class WriteZonedDatetime extends XmlVisitor {
             namespace -> methodBuilder.addStatement("output.writeStartElement($S, $S)", namespace, elementName),
             () -> methodBuilder.addStatement("output.writeStartElement($S)", elementName)
         );
-        methodBuilder.beginControlFlow(CHK_NULL, OBJECTS)
+        methodBuilder.beginControlFlow(CHK_NON_NULL, OBJECTS)
             .addStatement("output.writeCharacters(val.withZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", ZONE_OFFSET, DATE_TIME_FORMATTER)
             .nextControlFlow("else");
         logTrace(methodBuilder, "Supplied value for %s (element name %s) was null/blank, writing default of %s".formatted(analysedComponent.name(), elementName, writeAsDefaultValue));

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteZonedDatetime.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/elements/noncollections/WriteZonedDatetime.java
@@ -2,7 +2,7 @@ package io.github.cbarlin.aru.impl.xml.utils.elements.noncollections;
 
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
 import static io.github.cbarlin.aru.impl.Constants.Names.DATE_TIME_FORMATTER;
-import static io.github.cbarlin.aru.impl.Constants.Names.OFFSET_DATE_TIME;
+import static io.github.cbarlin.aru.impl.Constants.Names.ZONED_DATE_TIME;
 import static io.github.cbarlin.aru.impl.Constants.Names.ZONE_OFFSET;
 
 import java.util.Optional;
@@ -16,11 +16,11 @@ import io.github.cbarlin.aru.prism.prison.XmlElementPrism;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
 
 @ServiceProvider
-public class WriteOffsetDatetime extends XmlVisitor {
+public class WriteZonedDatetime extends XmlVisitor {
 
     private static final String CHK_NULL = "if ($T.nonNull(val))";
 
-    public WriteOffsetDatetime() {
+    public WriteZonedDatetime() {
         super(Claims.XML_WRITE_FIELD);
     }
 
@@ -37,7 +37,7 @@ public class WriteOffsetDatetime extends XmlVisitor {
     @Override
     protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
         final Optional<XmlElementPrism> optPrism = xmlElementPrism(analysedComponent);
-        if (optPrism.isPresent() && OFFSET_DATE_TIME.equals(analysedComponent.typeName())) {
+        if (optPrism.isPresent() && ZONED_DATE_TIME.equals(analysedComponent.typeName())) {
             // Nice!
             final XmlElementPrism prism = optPrism.get();
             final String elementName = elementName(analysedComponent, prism);
@@ -74,7 +74,7 @@ public class WriteOffsetDatetime extends XmlVisitor {
             namespace -> methodBuilder.addStatement("output.writeStartElement($S, $S)", namespace, elementName),
             () -> methodBuilder.addStatement("output.writeStartElement($S)", elementName)
         );
-        methodBuilder.addStatement("output.writeCharacters(val.atZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", ZONE_OFFSET, DATE_TIME_FORMATTER)
+        methodBuilder.addStatement("output.writeCharacters(val.withZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", ZONE_OFFSET, DATE_TIME_FORMATTER)
             .addStatement("output.writeEndElement()");
       
         if (!required) {
@@ -94,7 +94,7 @@ public class WriteOffsetDatetime extends XmlVisitor {
             () -> methodBuilder.addStatement("output.writeStartElement($S)", elementName)
         );
         methodBuilder.beginControlFlow(CHK_NULL, OBJECTS)
-            .addStatement("output.writeCharacters(val.atZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", ZONE_OFFSET, DATE_TIME_FORMATTER)
+            .addStatement("output.writeCharacters(val.withZoneSameInstant($T.UTC).format($T.ISO_OFFSET_DATE_TIME))", ZONE_OFFSET, DATE_TIME_FORMATTER)
             .nextControlFlow("else");
         logTrace(methodBuilder, "Supplied value for %s (element name %s) was null/blank, writing default of %s".formatted(analysedComponent.name(), elementName, writeAsDefaultValue));
         methodBuilder.addStatement("output.writeCharacters($S)", writeAsDefaultValue)

--- a/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/TimeBag.java
+++ b/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/TimeBag.java
@@ -27,7 +27,7 @@ public record TimeBag(
     OffsetDateTime offsetDateTimeAttributeRequired,
     @XmlElement(name = "offsetDateTimeElement")
     OffsetDateTime offsetDateTimeElement,
-    @XmlElement(name = "offsetDateTimeElementDefault", defaultValue = "1999-01-02T03:04:05.0001")
+    @XmlElement(name = "offsetDateTimeElementDefault", defaultValue = "This is a default value and not a valid date - lol")
     OffsetDateTime offsetDateTimeElementDefault,
     @XmlElement(name = "offsetDateTimeElementRequired", required = true)
     OffsetDateTime offsetDateTimeElementRequired,
@@ -40,7 +40,7 @@ public record TimeBag(
     ZonedDateTime zonedDateTimeAttributeRequired,
     @XmlElement(name = "zonedDateTimeElement")
     ZonedDateTime zonedDateTimeElement,
-    @XmlElement(name = "zonedDateTimeElementDefault", defaultValue = "1999-01-02T03:04:05.0001")
+    @XmlElement(name = "zonedDateTimeElementDefault", defaultValue = "This is a default value and not a valid date - lol")
     ZonedDateTime zonedDateTimeElementDefault,
     @XmlElement(name = "zonedDateTimeElementRequired", required = true)
     ZonedDateTime zonedDateTimeElementRequired,
@@ -53,7 +53,7 @@ public record TimeBag(
     LocalDateTime localDateTimeAttributeRequired,
     @XmlElement(name = "localDateTimeElement")
     LocalDateTime localDateTimeElement,
-    @XmlElement(name = "localDateTimeElementDefault", defaultValue = "1999-01-02T03:04:05.0001")
+    @XmlElement(name = "localDateTimeElementDefault", defaultValue = "This is a default value and not a valid date - lol")
     LocalDateTime localDateTimeElementDefault,
     @XmlElement(name = "localDateTimeElementRequired", required = true)
     LocalDateTime localDateTimeElementRequired,

--- a/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/TimeBag.java
+++ b/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/TimeBag.java
@@ -1,0 +1,64 @@
+package io.github.cbarlin.aru.tests.c_odd_types;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+
+import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
+import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.LoggingGeneration;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+@AdvancedRecordUtils(
+    xmlable = true,
+    wither = true,
+    merger = true,
+    logGeneration = LoggingGeneration.SLF4J_GENERATED_UTIL_INTERFACE,
+    createAllInterface = true
+)
+@XmlRootElement(
+    name = "TimeBag",
+    namespace = "nx://TimeTests"
+)
+public record TimeBag(
+    @XmlAttribute(name = "offsetDateTimeAttribute")
+    OffsetDateTime offsetDateTimeAttribute,
+    @XmlAttribute(name = "offsetDateTimeAttributeRequired", required = true)
+    OffsetDateTime offsetDateTimeAttributeRequired,
+    @XmlElement(name = "offsetDateTimeElement")
+    OffsetDateTime offsetDateTimeElement,
+    @XmlElement(name = "offsetDateTimeElementDefault", defaultValue = "1999-01-02T03:04:05.0001")
+    OffsetDateTime offsetDateTimeElementDefault,
+    @XmlElement(name = "offsetDateTimeElementRequired", required = true)
+    OffsetDateTime offsetDateTimeElementRequired,
+    @XmlElement(name = "offsetDateTimeElementRequiredDefault", required = true, defaultValue = "1999-01-02T03:04:55.0001")
+    OffsetDateTime offsetDateTimeElementRequiredDefault,
+
+    @XmlAttribute(name = "zonedDateTimeAttribute")
+    ZonedDateTime zonedDateTimeAttribute,
+    @XmlAttribute(name = "zonedDateTimeAttributeRequired", required = true)
+    ZonedDateTime zonedDateTimeAttributeRequired,
+    @XmlElement(name = "zonedDateTimeElement")
+    ZonedDateTime zonedDateTimeElement,
+    @XmlElement(name = "zonedDateTimeElementDefault", defaultValue = "1999-01-02T03:04:05.0001")
+    ZonedDateTime zonedDateTimeElementDefault,
+    @XmlElement(name = "zonedDateTimeElementRequired", required = true)
+    ZonedDateTime zonedDateTimeElementRequired,
+    @XmlElement(name = "zonedDateTimeElementRequiredDefault", required = true, defaultValue = "1999-01-02T03:04:55.0001")
+    ZonedDateTime zonedDateTimeElementRequiredDefault,
+
+    @XmlAttribute(name = "localDateTimeAttribute")
+    LocalDateTime localDateTimeAttribute,
+    @XmlAttribute(name = "localDateTimeAttributeRequired", required = true)
+    LocalDateTime localDateTimeAttributeRequired,
+    @XmlElement(name = "localDateTimeElement")
+    LocalDateTime localDateTimeElement,
+    @XmlElement(name = "localDateTimeElementDefault", defaultValue = "1999-01-02T03:04:05.0001")
+    LocalDateTime localDateTimeElementDefault,
+    @XmlElement(name = "localDateTimeElementRequired", required = true)
+    LocalDateTime localDateTimeElementRequired,
+    @XmlElement(name = "localDateTimeElementRequiredDefault", required = true, defaultValue = "1999-01-02T03:04:55.0001")
+    LocalDateTime localDateTimeElementRequiredDefault
+) implements TimeBagUtils.All {
+
+}

--- a/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/TimeTest.java
+++ b/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/TimeTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.TimeZone;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.github.cbarlin.aru.tests.xml_util.ConvertToXml;
@@ -12,6 +14,11 @@ import io.github.cbarlin.aru.tests.xml_util.ConvertToXml;
 class TimeTest {
 
     private static final ZonedDateTime TEST_TIME = ZonedDateTime.of(2025, 05, 3, 20, 27, 18, 44, ZoneId.of("Australia/Sydney"));
+
+    @BeforeAll
+    static void setSydneyTZ() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Australia/Sydney"));
+    }
 
     TimeBag buildNoDefaults() {
         return TimeBagUtils.builder()

--- a/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/TimeTest.java
+++ b/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/TimeTest.java
@@ -1,0 +1,53 @@
+package io.github.cbarlin.aru.tests.c_odd_types;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.cbarlin.aru.tests.xml_util.ConvertToXml;
+
+class TimeTest {
+
+    private static final ZonedDateTime TEST_TIME = ZonedDateTime.of(2025, 05, 3, 20, 27, 18, 44, ZoneId.of("Australia/Sydney"));
+
+    TimeBag buildNoDefaults() {
+        return TimeBagUtils.builder()
+            .offsetDateTimeAttribute(TEST_TIME.toOffsetDateTime())
+            .offsetDateTimeAttributeRequired(TEST_TIME.toOffsetDateTime())
+            .offsetDateTimeElement(TEST_TIME.toOffsetDateTime())
+            .offsetDateTimeElementRequired(TEST_TIME.toOffsetDateTime())
+            .zonedDateTimeAttribute(TEST_TIME)
+            .zonedDateTimeAttributeRequired(TEST_TIME)
+            .zonedDateTimeElement(TEST_TIME)
+            .zonedDateTimeElementRequired(TEST_TIME)
+            .localDateTimeAttribute(TEST_TIME.toLocalDateTime())
+            .localDateTimeAttributeRequired(TEST_TIME.toLocalDateTime())
+            .localDateTimeElement(TEST_TIME.toLocalDateTime())
+            .localDateTimeElementRequired(TEST_TIME.toLocalDateTime())
+            .build();
+    }
+
+    TimeBag buildWithDefaults() {
+        return buildNoDefaults().with()
+            .offsetDateTimeElementDefault(TEST_TIME.toOffsetDateTime())
+            .offsetDateTimeElementRequiredDefault(TEST_TIME.toOffsetDateTime())
+            .zonedDateTimeElementDefault(TEST_TIME)
+            .zonedDateTimeElementRequiredDefault(TEST_TIME)
+            .localDateTimeElementDefault(TEST_TIME.toLocalDateTime())
+            .localDateTimeElementRequiredDefault(TEST_TIME.toLocalDateTime())
+            .build();
+    }
+
+    @Test
+    void xmlNoDefaults() {
+        ConvertToXml.compareXml(out -> assertDoesNotThrow(() -> buildNoDefaults().writeSelfTo(out)), "expected_time_no_defaults.xml");
+    }
+
+    @Test
+    void xmlWithDefaults() {
+        ConvertToXml.compareXml(out -> assertDoesNotThrow(() -> buildWithDefaults().writeSelfTo(out)), "expected_time_with_defaults.xml");
+    }
+}

--- a/utils-tests/c_odd_types/src/test/resources/expected_time_no_defaults.xml
+++ b/utils-tests/c_odd_types/src/test/resources/expected_time_no_defaults.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<TimeBag
+    xmlns="nx://TimeTests"
+    localDateTimeAttribute="2025-05-03T10:27:18.000000044Z"
+    localDateTimeAttributeRequired="2025-05-03T10:27:18.000000044Z"
+    offsetDateTimeAttribute="2025-05-03T10:27:18.000000044Z"
+    offsetDateTimeAttributeRequired="2025-05-03T10:27:18.000000044Z"
+    zonedDateTimeAttribute="2025-05-03T10:27:18.000000044Z"
+    zonedDateTimeAttributeRequired="2025-05-03T10:27:18.000000044Z"
+>
+    <!-- 8pm Australia/Sydney becomes 10am UTC -->
+    <offsetDateTimeElement>2025-05-03T10:27:18.000000044Z</offsetDateTimeElement>
+    <offsetDateTimeElementDefault>1999-01-02T03:04:05.0001</offsetDateTimeElementDefault>
+    <offsetDateTimeElementRequired>2025-05-03T10:27:18.000000044Z</offsetDateTimeElementRequired>
+    <offsetDateTimeElementRequiredDefault>1999-01-02T03:04:55.0001</offsetDateTimeElementRequiredDefault>
+    <zonedDateTimeElement>2025-05-03T10:27:18.000000044Z</zonedDateTimeElement>
+    <zonedDateTimeElementDefault>1999-01-02T03:04:05.0001</zonedDateTimeElementDefault>
+    <zonedDateTimeElementRequired>2025-05-03T10:27:18.000000044Z</zonedDateTimeElementRequired>
+    <zonedDateTimeElementRequiredDefault>1999-01-02T03:04:55.0001</zonedDateTimeElementRequiredDefault>
+    <localDateTimeElement>2025-05-03T10:27:18.000000044Z</localDateTimeElement>
+    <localDateTimeElementDefault>1999-01-02T03:04:05.0001</localDateTimeElementDefault>
+    <localDateTimeElementRequired>2025-05-03T10:27:18.000000044Z</localDateTimeElementRequired>
+    <localDateTimeElementRequiredDefault>1999-01-02T03:04:55.0001</localDateTimeElementRequiredDefault>
+</TimeBag>

--- a/utils-tests/c_odd_types/src/test/resources/expected_time_no_defaults.xml
+++ b/utils-tests/c_odd_types/src/test/resources/expected_time_no_defaults.xml
@@ -10,15 +10,15 @@
 >
     <!-- 8pm Australia/Sydney becomes 10am UTC -->
     <offsetDateTimeElement>2025-05-03T10:27:18.000000044Z</offsetDateTimeElement>
-    <offsetDateTimeElementDefault>1999-01-02T03:04:05.0001</offsetDateTimeElementDefault>
+    <offsetDateTimeElementDefault>This is a default value and not a valid date - lol</offsetDateTimeElementDefault>
     <offsetDateTimeElementRequired>2025-05-03T10:27:18.000000044Z</offsetDateTimeElementRequired>
     <offsetDateTimeElementRequiredDefault>1999-01-02T03:04:55.0001</offsetDateTimeElementRequiredDefault>
     <zonedDateTimeElement>2025-05-03T10:27:18.000000044Z</zonedDateTimeElement>
-    <zonedDateTimeElementDefault>1999-01-02T03:04:05.0001</zonedDateTimeElementDefault>
+    <zonedDateTimeElementDefault>This is a default value and not a valid date - lol</zonedDateTimeElementDefault>
     <zonedDateTimeElementRequired>2025-05-03T10:27:18.000000044Z</zonedDateTimeElementRequired>
     <zonedDateTimeElementRequiredDefault>1999-01-02T03:04:55.0001</zonedDateTimeElementRequiredDefault>
     <localDateTimeElement>2025-05-03T10:27:18.000000044Z</localDateTimeElement>
-    <localDateTimeElementDefault>1999-01-02T03:04:05.0001</localDateTimeElementDefault>
+    <localDateTimeElementDefault>This is a default value and not a valid date - lol</localDateTimeElementDefault>
     <localDateTimeElementRequired>2025-05-03T10:27:18.000000044Z</localDateTimeElementRequired>
     <localDateTimeElementRequiredDefault>1999-01-02T03:04:55.0001</localDateTimeElementRequiredDefault>
 </TimeBag>

--- a/utils-tests/c_odd_types/src/test/resources/expected_time_with_defaults.xml
+++ b/utils-tests/c_odd_types/src/test/resources/expected_time_with_defaults.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<TimeBag
+    xmlns="nx://TimeTests"
+    localDateTimeAttribute="2025-05-03T10:27:18.000000044Z"
+    localDateTimeAttributeRequired="2025-05-03T10:27:18.000000044Z"
+    offsetDateTimeAttribute="2025-05-03T10:27:18.000000044Z"
+    offsetDateTimeAttributeRequired="2025-05-03T10:27:18.000000044Z"
+    zonedDateTimeAttribute="2025-05-03T10:27:18.000000044Z"
+    zonedDateTimeAttributeRequired="2025-05-03T10:27:18.000000044Z"
+>
+    <!-- 8pm Australia/Sydney becomes 10am UTC -->
+    <offsetDateTimeElement>2025-05-03T10:27:18.000000044Z</offsetDateTimeElement>
+    <offsetDateTimeElementDefault>2025-05-03T10:27:18.000000044Z</offsetDateTimeElementDefault>
+    <offsetDateTimeElementRequired>2025-05-03T10:27:18.000000044Z</offsetDateTimeElementRequired>
+    <offsetDateTimeElementRequiredDefault>2025-05-03T10:27:18.000000044Z</offsetDateTimeElementRequiredDefault>
+    <zonedDateTimeElement>2025-05-03T10:27:18.000000044Z</zonedDateTimeElement>
+    <zonedDateTimeElementDefault>2025-05-03T10:27:18.000000044Z</zonedDateTimeElementDefault>
+    <zonedDateTimeElementRequired>2025-05-03T10:27:18.000000044Z</zonedDateTimeElementRequired>
+    <zonedDateTimeElementRequiredDefault>2025-05-03T10:27:18.000000044Z</zonedDateTimeElementRequiredDefault>
+    <localDateTimeElement>2025-05-03T10:27:18.000000044Z</localDateTimeElement>
+    <localDateTimeElementDefault>2025-05-03T10:27:18.000000044Z</localDateTimeElementDefault>
+    <localDateTimeElementRequired>2025-05-03T10:27:18.000000044Z</localDateTimeElementRequired>
+    <localDateTimeElementRequiredDefault>2025-05-03T10:27:18.000000044Z</localDateTimeElementRequiredDefault>
+</TimeBag>


### PR DESCRIPTION
Fixes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for serialising and deserialising `LocalDateTime` and `ZonedDateTime` fields to and from XML, including handling of required fields and default values.
  - Introduced new classes to improve XML writing logic for `LocalDateTime` and `ZonedDateTime` components.
  - Introduced a new `TimeBag` record with comprehensive date-time attribute and element coverage for XML binding.
- **Bug Fixes**
  - Improved UTC conversion and formatting for `LocalDateTime` fields when writing XML attributes.
  - Refined XML output logic for date-time fields with default values to ensure correct serialisation and clearer control flow.
- **Tests**
  - Added new tests and XML resources to verify correct handling of date-time fields in XML, covering scenarios with and without default values.
- **Chores**
  - Updated version constants in annotations to reflect the latest minor and patch versions.
  - Adjusted code review tool configuration to relax standards for test code and disable docstring finishing touches in assertive profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->