### PR TITLE
Avaje JSONB import support for interfaces

### DIFF
--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
@@ -76,9 +76,11 @@ public enum Constants {
     public enum Names {
         ;
         private static final String XML_ANNOTATIONS = "jakarta.xml.bind.annotation";
+        private static final String AVAJE_JSONB = "io.avaje.jsonb";
         public static final ClassName AVAJE_CONSTRAINT_VIOLATION = ClassName.get("io.avaje.validation", "ConstraintViolationException");
-        public static final ClassName AVAJE_JSONB_IMPORT = ClassName.get("io.avaje.jsonb", "Json", "Import");
-        public static final ClassName AVAJE_JSONB_IGNORE = ClassName.get("io.avaje.jsonb", "Json", "Ignore");
+        public static final ClassName AVAJE_JSONB_IMPORT = ClassName.get(AVAJE_JSONB, "Json", "Import");
+        public static final ClassName AVAJE_JSONB_IGNORE = ClassName.get(AVAJE_JSONB, "Json", "Ignore");
+        public static final ClassName AVAJE_JSONB_SUBTYPE = ClassName.get(AVAJE_JSONB, "Json", "SubType");
         public static final ClassName AVAJE_VALIDATOR = ClassName.get("io.avaje.validation", "Validator");
         public static final ClassName BI_CONSUMER = ClassName.get(BiConsumer.class);
         public static final ClassName BIG_DECIMAL = ClassName.get("java.math", "BigDecimal");

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/misc/JsonbImportInterfaceAnnotator.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/misc/JsonbImportInterfaceAnnotator.java
@@ -40,12 +40,12 @@ public class JsonbImportInterfaceAnnotator extends InterfaceVisitor {
                 continue;
             }
             final ClassName othClassName = ClassName.get(te);
-            formatBuilder.append("@$T(type = $T.class),");
+            formatBuilder.append("\n\t@$T(type = $T.class),");
             params.add(Names.AVAJE_JSONB_SUBTYPE);
             params.add(othClassName);
         }
 
-        formatBuilder.append('}');
+        formatBuilder.append('\n').append('}');
         jsonbAnnotation.addMember("subtypes", formatBuilder.toString(), params.toArray());
         
         analysedInterface.utilsClass()

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/misc/JsonbImportInterfaceAnnotator.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/misc/JsonbImportInterfaceAnnotator.java
@@ -1,0 +1,56 @@
+package io.github.cbarlin.aru.impl.misc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.types.AnalysedInterface;
+import io.github.cbarlin.aru.core.types.ProcessingTarget;
+import io.github.cbarlin.aru.core.visitors.InterfaceVisitor;
+import io.github.cbarlin.aru.impl.Constants.Claims;
+import io.github.cbarlin.aru.impl.Constants.Names;
+import io.micronaut.sourcegen.javapoet.AnnotationSpec;
+import io.micronaut.sourcegen.javapoet.ClassName;
+
+@ServiceProvider
+public class JsonbImportInterfaceAnnotator extends InterfaceVisitor {
+    public JsonbImportInterfaceAnnotator() {
+        super(Claims.MISC_AVAJE_JSONB_IMPORT);
+    }
+
+    @Override
+    public int specificity() {
+        return 0;
+    }
+
+    @Override
+    protected boolean visitInterfaceImpl(final AnalysedInterface analysedInterface) {
+        final AnnotationSpec.Builder jsonbAnnotation = AnnotationSpec.builder(Names.AVAJE_JSONB_IMPORT)
+            .addMember("value", "{$T.class}", analysedInterface.className());
+
+        final StringBuilder formatBuilder = new StringBuilder("{");
+        final List<Object> params = new ArrayList<>();
+
+        for(final ProcessingTarget target : analysedInterface.implementingTypes()) {
+            final ClassName othClassName = ClassName.get(target.typeElement());
+            formatBuilder.append("@$T(type = $T.class),");
+            params.add(Names.AVAJE_JSONB_SUBTYPE);
+            params.add(othClassName);
+        }
+
+        formatBuilder.append('}');
+        jsonbAnnotation.addMember("subtypes", formatBuilder.toString(), params.toArray());
+        
+        analysedInterface.utilsClass()
+            .builder()
+            .addAnnotation(jsonbAnnotation.build());
+        return true;
+    }
+
+    @Override
+    public boolean isApplicable(final AnalysedInterface target) {
+        return Boolean.TRUE.equals(target.settings().prism().addJsonbImportAnnotation());
+    }
+
+    
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/misc/JsonbImportInterfaceAnnotator.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/misc/JsonbImportInterfaceAnnotator.java
@@ -2,6 +2,9 @@ package io.github.cbarlin.aru.impl.misc;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
+import javax.lang.model.element.TypeElement;
 
 import io.avaje.spi.ServiceProvider;
 import io.github.cbarlin.aru.core.types.AnalysedInterface;
@@ -32,7 +35,11 @@ public class JsonbImportInterfaceAnnotator extends InterfaceVisitor {
         final List<Object> params = new ArrayList<>();
 
         for(final ProcessingTarget target : analysedInterface.implementingTypes()) {
-            final ClassName othClassName = ClassName.get(target.typeElement());
+            final TypeElement te = target.typeElement();
+            if (Objects.isNull(te)) {
+                continue;
+            }
+            final ClassName othClassName = ClassName.get(te);
             formatBuilder.append("@$T(type = $T.class),");
             params.add(Names.AVAJE_JSONB_SUBTYPE);
             params.add(othClassName);

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/types/AnalysedInterface.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/types/AnalysedInterface.java
@@ -2,9 +2,9 @@ package io.github.cbarlin.aru.core.types;
 
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULL_MARKED;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
@@ -20,7 +20,7 @@ import io.github.cbarlin.aru.prism.prison.JsonSubTypesPrism.TypePrism;
 import io.github.cbarlin.aru.prism.prison.XmlSeeAlsoPrism;
 
 public final class AnalysedInterface extends AnalysedType {
-    private final Set<ProcessingTarget> implementingTypes = new HashSet<>();
+    private final Set<ProcessingTarget> implementingTypes = new TreeSet<>();
 
     public AnalysedInterface(final TypeElement element, final UtilsProcessingContext context, final AdvRecUtilsSettings parentSettings) {
         super(element, context, parentSettings);

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/types/AnalysedInterface.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/types/AnalysedInterface.java
@@ -2,8 +2,10 @@ package io.github.cbarlin.aru.core.types;
 
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULL_MARKED;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeSet;
 
 import javax.lang.model.element.ElementKind;
@@ -20,7 +22,7 @@ import io.github.cbarlin.aru.prism.prison.JsonSubTypesPrism.TypePrism;
 import io.github.cbarlin.aru.prism.prison.XmlSeeAlsoPrism;
 
 public final class AnalysedInterface extends AnalysedType {
-    private final Set<ProcessingTarget> implementingTypes = new TreeSet<>();
+    private final SortedSet<ProcessingTarget> implementingTypes = new TreeSet<>();
 
     public AnalysedInterface(final TypeElement element, final UtilsProcessingContext context, final AdvRecUtilsSettings parentSettings) {
         super(element, context, parentSettings);
@@ -107,7 +109,7 @@ public final class AnalysedInterface extends AnalysedType {
     }
     
     public Set<ProcessingTarget> implementingTypes() {
-        return Set.copyOf(implementingTypes);
+        return Collections.unmodifiableSortedSet(implementingTypes);
     }
 
     public GenerationArtifact<?> builderArtifact() {

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/types/ProcessingTarget.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/types/ProcessingTarget.java
@@ -7,7 +7,6 @@ import org.jspecify.annotations.Nullable;
 import io.github.cbarlin.aru.core.AdvancedRecordUtilsPrism;
 import io.github.cbarlin.aru.core.ClaimableOperation;
 import io.github.cbarlin.aru.core.artifacts.GenerationArtifact;
-
 import io.micronaut.sourcegen.javapoet.ClassName;
 
 /**
@@ -21,7 +20,7 @@ import io.micronaut.sourcegen.javapoet.ClassName;
  */
 // Ignore the generics, they aren't relevant in practice
 @SuppressWarnings({"java:S1452"})
-public sealed interface ProcessingTarget permits LibraryLoadedTarget, AnalysedType {
+public sealed interface ProcessingTarget extends Comparable<ProcessingTarget> permits LibraryLoadedTarget, AnalysedType {
     
     public TypeElement typeElement();
 
@@ -39,4 +38,9 @@ public sealed interface ProcessingTarget permits LibraryLoadedTarget, AnalysedTy
     public AdvancedRecordUtilsPrism prism();
 
     public GenerationArtifact<?> builderArtifact();
+
+    @Override
+    default int compareTo(ProcessingTarget o) {
+        return utilsClassName().compareTo(o.utilsClassName());
+    }
 }


### PR DESCRIPTION
Also ensure that implementations are always processed in a consistent order to make builds reproduceable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced automatic generation of JSON-B import annotations for interfaces, including subtype information.

* **Improvements**
  * Enhanced internal handling of implementing types to ensure consistent ordering.
  * Improved comparison logic for processing targets to support ordered collections.

* **Chores**
  * Refined internal constants for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->