### PR TITLE
Unify `merge` and `diff` implementation behaviour

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -29,9 +29,10 @@ reviews:
         All the code for the annotation processor should be checked, please.
 
         Please do these:
-        * Review code using Java 21 standards, taking into account the vague rules and samples defined in `CONTRIBUTING.md`
+        * Review code using Java 17 standards, taking into account the vague rules and samples defined in `CONTRIBUTING.md`
         * Validate that code indentation uses spaces, not tabs, with an indent of multiple of 4
-        * Propose changes that only use the Java 21 API, not the API of Guava
+        * Propose changes that only use the Java 17 API, not the API of Guava 
+            * Note that we have not fully transitioned to 17 support, so some Java 21 code is still present. We should prefer 17 code though.
 
         Please keep in mind:
         * The pattern matching `instanceof` expression safely handles `null`, returning `false`
@@ -51,7 +52,7 @@ reviews:
         For the code:
         * When providing defaults for the annotation values, we have some rules that should be enforced:
            * Principle of Least Astonishment
-           * Dependencies are not required (minus commons-lang3)
+           * Dependencies are not required
         * Non-default values may add dependency requirements - these should be documented (and added as optional to the pom)
     - path: 'aru-prism-prison/**'
       instructions: |

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/diff/DifferVisitor.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/diff/DifferVisitor.java
@@ -16,10 +16,7 @@ import io.github.cbarlin.aru.core.impl.types.AnalysedCollectionComponent;
 import io.github.cbarlin.aru.core.types.AnalysedRecord;
 import io.github.cbarlin.aru.core.visitors.RecordVisitor;
 import io.github.cbarlin.aru.impl.Constants.Claims;
-import io.micronaut.sourcegen.javapoet.ArrayTypeName;
-import io.micronaut.sourcegen.javapoet.ClassName;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
-import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
 import io.micronaut.sourcegen.javapoet.TypeName;
 
 public abstract class DifferVisitor extends RecordVisitor {
@@ -94,25 +91,5 @@ public abstract class DifferVisitor extends RecordVisitor {
 
     protected static String hasChangedStaticMethodName(final TypeName originalTypeName) {
         return HAS_CHANGED_STATIC_METHOD_FMT.formatted(typeNameToPartialMethodName(originalTypeName));
-    }
-
-    @SuppressWarnings({"java:S6880"}) // There is a ticket to make us work on Java 17 - let's not make more work for ourselves!
-    protected static String typeNameToPartialMethodName(final TypeName originalTypeName) {
-        if (originalTypeName.isAnnotated()) {
-            return typeNameToPartialMethodName(originalTypeName.withoutAnnotations());
-        }
-
-        if (originalTypeName instanceof final ClassName cn) {
-            return cn.simpleName();
-        } else if (originalTypeName instanceof final ParameterizedTypeName ptn) {
-            final String simple = ptn.rawType.simpleName();
-            final StringBuilder kinds = new StringBuilder();
-            ptn.typeArguments.forEach(t -> kinds.append(typeNameToPartialMethodName(t)));
-            return simple + kinds;
-        } else if (originalTypeName instanceof final ArrayTypeName atn) {
-            return typeNameToPartialMethodName(atn.componentType) + "Arr";
-        } else {
-            return originalTypeName.withoutAnnotations().toString();
-        }
     }
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/MergerVisitor.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/MergerVisitor.java
@@ -4,6 +4,8 @@ import static io.github.cbarlin.aru.impl.Constants.Claims.INTERNAL_MATCHING_IFAC
 import static io.github.cbarlin.aru.impl.Constants.InternalReferenceNames.INTERNAL_MATCHING_IFACE_NAME;
 import static io.github.cbarlin.aru.impl.Constants.InternalReferenceNames.MERGER_UTILS_CLASS;
 
+import java.util.Locale;
+
 import io.github.cbarlin.aru.core.AdvancedRecordUtilsPrism.BuilderOptionsPrism;
 import io.github.cbarlin.aru.core.AdvancedRecordUtilsPrism.MergerOptionsPrism;
 import io.github.cbarlin.aru.core.ClaimableOperation;
@@ -11,8 +13,11 @@ import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
 import io.github.cbarlin.aru.core.types.AnalysedRecord;
 import io.github.cbarlin.aru.core.visitors.RecordVisitor;
 import io.github.cbarlin.aru.impl.Constants.Claims;
+import io.micronaut.sourcegen.javapoet.TypeName;
 
 public abstract class MergerVisitor extends RecordVisitor {
+
+    private static final String MERGE_STATIC_METHOD_FMT = "merge%s";
 
     protected ToBeBuilt mergerInterface;
     protected ToBeBuilt mergerStaticClass;
@@ -45,5 +50,14 @@ public abstract class MergerVisitor extends RecordVisitor {
     @Override
     public final int specificity() {
         return 1 + innerSpecificity();
+    }
+
+    protected static String capitalise(final String variableName) {
+        return (variableName.length() < 2) ? variableName.toUpperCase(Locale.ROOT)
+                : (Character.toUpperCase(variableName.charAt(0)) + variableName.substring(1));
+    }
+
+    protected static String mergeStaticMethodName(final TypeName originalTypeName) {
+        return MERGE_STATIC_METHOD_FMT.formatted(typeNameToPartialMethodName(originalTypeName));
     }
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/iface/MergeMethod.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/iface/MergeMethod.java
@@ -19,6 +19,7 @@ import io.github.cbarlin.aru.impl.Constants.Claims;
 import io.github.cbarlin.aru.impl.merger.MergerVisitor;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
 import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
 
 @ServiceProvider
 public final class MergeMethod extends MergerVisitor {
@@ -65,7 +66,7 @@ public final class MergeMethod extends MergerVisitor {
             format.add(".$L($T.$L(this.$L(), optOther.map($T::$L).orElse(null)))");
             args.add(parameter.getSimpleName().toString());
             args.add(mergerStaticClass.className());
-            args.add(parameter.getSimpleName().toString());
+            args.add(mergeStaticMethodName(TypeName.get(parameter.asType())));
             args.add(parameter.getSimpleName().toString());
             args.add(analysedRecord.intendedType());
             args.add(parameter.getSimpleName().toString());

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/Fallback.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/Fallback.java
@@ -3,6 +3,9 @@ package io.github.cbarlin.aru.impl.merger.utils;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.lang.model.element.Modifier;
 
 import io.avaje.spi.ServiceProvider;
@@ -16,6 +19,8 @@ import io.micronaut.sourcegen.javapoet.ParameterSpec;
 
 @ServiceProvider
 public final class Fallback extends MergerVisitor {
+
+    private final Set<String> processedSpecs = HashSet.newHashSet(20);
 
     public Fallback() {
         super(Claims.MERGER_ADD_FIELD_MERGER_METHOD);
@@ -34,29 +39,33 @@ public final class Fallback extends MergerVisitor {
     @Override
     protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
         final var targetTn = analysedComponent.typeName();
-        final ParameterSpec paramA = ParameterSpec.builder(targetTn, "elA", Modifier.FINAL)
-            .addAnnotation(NULLABLE)
-            .addJavadoc("The preferred input")
-            .build();
-        final ParameterSpec paramB = ParameterSpec.builder(targetTn, "elB", Modifier.FINAL)
-            .addAnnotation(NULLABLE)
-            .addJavadoc("The non-preferred input")
-            .build();
-        
-        final MethodSpec.Builder method = mergerStaticClass.createMethod(analysedComponent.name(), claimableOperation);
-        method.modifiers.clear();
-        method.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-            .addAnnotation(NULLABLE)
-            .addParameter(paramA)
-            .addParameter(paramB)
-            .returns(targetTn)
-            .addJavadoc("Merger for the field {@code $L}", analysedComponent.name())
-            .beginControlFlow("if ($T.isNull(elA))", OBJECTS)
-            .addStatement("return elB")
-            .endControlFlow()
-            .addStatement("return elA");
+        final String methodName = mergeStaticMethodName(targetTn);
+        if (processedSpecs.add(methodName)) {
+            final ParameterSpec paramA = ParameterSpec.builder(targetTn, "elA", Modifier.FINAL)
+                .addAnnotation(NULLABLE)
+                .addJavadoc("The preferred input")
+                .build();
+            final ParameterSpec paramB = ParameterSpec.builder(targetTn, "elB", Modifier.FINAL)
+                .addAnnotation(NULLABLE)
+                .addJavadoc("The non-preferred input")
+                .build();
+            
+            final MethodSpec.Builder method = mergerStaticClass.createMethod(methodName, claimableOperation);
+            method.modifiers.clear();
+            method.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                .addAnnotation(NULLABLE)
+                .addParameter(paramA)
+                .addParameter(paramB)
+                .returns(targetTn)
+                .addJavadoc("Merger for fields of class {@link $T}", targetTn)
+                .beginControlFlow("if ($T.isNull(elA))", OBJECTS)
+                .addStatement("return elB")
+                .endControlFlow()
+                .addStatement("return elA");
 
-        AnnotationSupplier.addGeneratedAnnotation(method, this);
+            AnnotationSupplier.addGeneratedAnnotation(method, this);
+        }
+        
         return true;
     }
 

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/MergeMethod.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/MergeMethod.java
@@ -18,6 +18,7 @@ import io.github.cbarlin.aru.impl.Constants.Claims;
 import io.github.cbarlin.aru.impl.merger.MergerVisitor;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
 import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
 
 @ServiceProvider
 public final class MergeMethod extends MergerVisitor {
@@ -103,7 +104,7 @@ public final class MergeMethod extends MergerVisitor {
             format.add(".$L($T.$L(preferred.$L(), other.$L()))");
             args.add(parameter.getSimpleName().toString());
             args.add(mergerStaticClass.className());
-            args.add(parameter.getSimpleName().toString());
+            args.add(mergeStaticMethodName(TypeName.get(parameter.asType())));
             args.add(parameter.getSimpleName().toString());
             args.add(parameter.getSimpleName().toString());
         }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/MergeOptionalPrimitives.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/MergeOptionalPrimitives.java
@@ -4,6 +4,9 @@ import static io.github.cbarlin.aru.core.CommonsConstants.Names.NOT_NULL;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.lang.model.element.Modifier;
 
 import io.avaje.spi.ServiceProvider;
@@ -18,6 +21,8 @@ import io.micronaut.sourcegen.javapoet.ParameterSpec;
 
 @ServiceProvider
 public final class MergeOptionalPrimitives extends MergerVisitor {
+
+    private final Set<String> processedSpecs = HashSet.newHashSet(5);
 
     public MergeOptionalPrimitives() {
         super(Claims.MERGER_ADD_FIELD_MERGER_METHOD);
@@ -37,31 +42,36 @@ public final class MergeOptionalPrimitives extends MergerVisitor {
     protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
         if (analysedComponent instanceof AnalysedOptionalPrimitiveComponent component) {
             final var targetTn = component.typeName();
-            final ParameterSpec paramA = ParameterSpec.builder(targetTn, "elA", Modifier.FINAL)
-                .addAnnotation(NULLABLE)
-                .addJavadoc("The preferred input")
-                .build();
-            final ParameterSpec paramB = ParameterSpec.builder(targetTn, "elB", Modifier.FINAL)
-                .addAnnotation(NULLABLE)
-                .addJavadoc("The non-preferred input")
-                .build();
-            
-            final MethodSpec.Builder method = mergerStaticClass.createMethod(component.name(), claimableOperation);
-            method.modifiers.clear();
-            method.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-                .addAnnotation(NOT_NULL)
-                .addParameter(paramA)
-                .addParameter(paramB)
-                .returns(targetTn)
-                .addJavadoc("Merger for the field {@code $L}", component.name())
-                .beginControlFlow("if ($T.nonNull(elA) && elA.isPresent())", OBJECTS)
-                .addStatement("return elA")
-                .nextControlFlow("else if($T.nonNull(elB) && elB.isPresent())", OBJECTS)
-                .addStatement("return elB")
-                .endControlFlow()
-                .addStatement("return $T.empty()", component.typeName());
+            final String methodName = mergeStaticMethodName(targetTn);
 
-            AnnotationSupplier.addGeneratedAnnotation(method, this);
+            if (processedSpecs.add(methodName)) {
+                final ParameterSpec paramA = ParameterSpec.builder(targetTn, "elA", Modifier.FINAL)
+                    .addAnnotation(NULLABLE)
+                    .addJavadoc("The preferred input")
+                    .build();
+                final ParameterSpec paramB = ParameterSpec.builder(targetTn, "elB", Modifier.FINAL)
+                    .addAnnotation(NULLABLE)
+                    .addJavadoc("The non-preferred input")
+                    .build();
+                
+                final MethodSpec.Builder method = mergerStaticClass.createMethod(methodName, claimableOperation);
+                method.modifiers.clear();
+                method.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                    .addAnnotation(NOT_NULL)
+                    .addParameter(paramA)
+                    .addParameter(paramB)
+                    .returns(targetTn)
+                    .addJavadoc("Merger for fields of class {@link $T}", targetTn)
+                    .beginControlFlow("if ($T.nonNull(elA) && elA.isPresent())", OBJECTS)
+                    .addStatement("return elA")
+                    .nextControlFlow("else if($T.nonNull(elB) && elB.isPresent())", OBJECTS)
+                    .addStatement("return elB")
+                    .endControlFlow()
+                    .addStatement("return $T.empty()", component.typeName());
+
+                AnnotationSupplier.addGeneratedAnnotation(method, this);
+            }
+            
             return true;
         }
         return false;

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/OtherProcessed.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/OtherProcessed.java
@@ -3,6 +3,9 @@ package io.github.cbarlin.aru.impl.merger.utils;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
 import static io.github.cbarlin.aru.impl.Constants.InternalReferenceNames.MERGER_UTILS_CLASS;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.lang.model.element.Modifier;
 
 import io.avaje.spi.ServiceProvider;
@@ -17,6 +20,8 @@ import io.micronaut.sourcegen.javapoet.ParameterSpec;
 
 @ServiceProvider
 public final class OtherProcessed extends MergerVisitor {
+
+    private final Set<String> processedSpecs = HashSet.newHashSet(10);
 
     public OtherProcessed() {
         super(Claims.MERGER_ADD_FIELD_MERGER_METHOD);
@@ -36,34 +41,37 @@ public final class OtherProcessed extends MergerVisitor {
     protected boolean visitComponentImpl(AnalysedComponent analysedComponent) {
         if (supportedComponent(analysedComponent)) {
             // OK, the other side has a merger utils I can hook into!
-            
-            // The if statement handled these for us
-            @SuppressWarnings({"java:S1854", "java:S3655"})
-            final AnalysedRecord other = (AnalysedRecord) analysedComponent.targetAnalysedType().get();
-
-            final ClassName otherMergerClassName = other.utilsClassChildClass(MERGER_UTILS_CLASS, Claims.MERGER_STATIC_CLASS).className();
             final var targetTn = analysedComponent.typeName();
-            final ParameterSpec paramA = ParameterSpec.builder(targetTn, "elA", Modifier.FINAL)
-                .addAnnotation(NULLABLE)
-                .addJavadoc("The preferred input")
-                .build();
-            final ParameterSpec paramB = ParameterSpec.builder(targetTn, "elB", Modifier.FINAL)
-                .addAnnotation(NULLABLE)
-                .addJavadoc("The non-preferred input")
-                .build();
+            final String methodName = mergeStaticMethodName(targetTn);
+            if (processedSpecs.add(methodName)) {
+                // The if statement handled these for us
+                @SuppressWarnings({"java:S1854", "java:S3655"})
+                final AnalysedRecord other = (AnalysedRecord) analysedComponent.targetAnalysedType().get();
 
-            final MethodSpec.Builder method = mergerStaticClass.createMethod(analysedComponent.name(), claimableOperation);
-            method.modifiers.clear();
-            method.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-                .addAnnotation(NULLABLE)
-                .addParameter(paramA)
-                .addParameter(paramB)
-                .returns(targetTn)
-                .addJavadoc("Merger for the field {@code $L}", analysedComponent.name())
-                .addStatement("return $T.merge(elA, elB)", otherMergerClassName);
+                final ClassName otherMergerClassName = other.utilsClassChildClass(MERGER_UTILS_CLASS, Claims.MERGER_STATIC_CLASS).className();
+                final ParameterSpec paramA = ParameterSpec.builder(targetTn, "elA", Modifier.FINAL)
+                    .addAnnotation(NULLABLE)
+                    .addJavadoc("The preferred input")
+                    .build();
+                final ParameterSpec paramB = ParameterSpec.builder(targetTn, "elB", Modifier.FINAL)
+                    .addAnnotation(NULLABLE)
+                    .addJavadoc("The non-preferred input")
+                    .build();
 
-            AnnotationSupplier.addGeneratedAnnotation(method, this);
-            analysedComponent.parentRecord().addCrossReference(other);
+                final MethodSpec.Builder method = mergerStaticClass.createMethod(methodName, claimableOperation);
+                method.modifiers.clear();
+                method.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                    .addAnnotation(NULLABLE)
+                    .addParameter(paramA)
+                    .addParameter(paramB)
+                    .returns(targetTn)
+                    .addJavadoc("Merger for fields of class {@link $T}", targetTn)
+                    .addStatement("return $T.merge(elA, elB)", otherMergerClassName);
+
+                AnnotationSupplier.addGeneratedAnnotation(method, this);
+                analysedComponent.parentRecord().addCrossReference(other);
+            }
+            
             return true;
         }
         return false;

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/collection/ListMerge.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/collection/ListMerge.java
@@ -5,6 +5,9 @@ import static io.github.cbarlin.aru.core.CommonsConstants.Names.LIST;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.lang.model.element.Modifier;
 
 import io.avaje.spi.ServiceProvider;
@@ -21,6 +24,8 @@ import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
 
 @ServiceProvider
 public final class ListMerge extends MergerVisitor {
+
+    private final Set<String> processedSpecs = HashSet.newHashSet(5);
 
     public ListMerge() {
         super(Claims.MERGER_ADD_FIELD_MERGER_METHOD);
@@ -39,49 +44,55 @@ public final class ListMerge extends MergerVisitor {
     @Override
     protected boolean visitComponentImpl(AnalysedComponent analysedComponent) {
         if (analysedComponent instanceof AnalysedCollectionComponent acc && acc.isList()) {
-            final var innerType = acc.unNestedPrimaryTypeName();
-            final var mutableCollectionType = ARRAY_LIST;
-            final var baseType = LIST;
+            final var targetTn = analysedComponent.typeName();
+            final String methodName = mergeStaticMethodName(targetTn);
+            if (processedSpecs.add(methodName)) {
+                final var innerType = acc.unNestedPrimaryTypeName();
+                final var mutableCollectionType = ARRAY_LIST;
+                final var baseType = LIST;
 
-            final ParameterizedTypeName paramTypeName = ParameterizedTypeName.get(baseType, innerType);
-            final ParameterizedTypeName mutableTypeName = ParameterizedTypeName.get(mutableCollectionType, innerType);
+                final ParameterizedTypeName paramTypeName = ParameterizedTypeName.get(baseType, innerType);
+                final ParameterizedTypeName mutableTypeName = ParameterizedTypeName.get(mutableCollectionType, innerType);
 
 
-            final ParameterSpec paramA = ParameterSpec.builder(paramTypeName, "elA", Modifier.FINAL)
-                .addAnnotation(NULLABLE)
-                .addJavadoc("The preferred input")
-                .build();
-            
-            final ParameterSpec paramB = ParameterSpec.builder(paramTypeName, "elB", Modifier.FINAL)
-                .addAnnotation(NULLABLE)
-                .addJavadoc("The non-preferred input")
-                .build();
+                final ParameterSpec paramA = ParameterSpec.builder(paramTypeName, "elA", Modifier.FINAL)
+                    .addAnnotation(NULLABLE)
+                    .addJavadoc("The preferred input")
+                    .build();
+                
+                final ParameterSpec paramB = ParameterSpec.builder(paramTypeName, "elB", Modifier.FINAL)
+                    .addAnnotation(NULLABLE)
+                    .addJavadoc("The non-preferred input")
+                    .build();
 
-            final MethodSpec.Builder method = mergerStaticClass.createMethod(analysedComponent.name(), claimableOperation);
-            method.modifiers.clear();
-            method.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-                .addAnnotation(NULLABLE)
-                .addParameter(paramA)
-                .addParameter(paramB)
-                .returns(paramTypeName).addJavadoc("Merger for the field {@code $L}", analysedComponent.name())
-                .beginControlFlow("if ($T.isNull(elA) || elA.isEmpty())", OBJECTS)
-                .addStatement("return elB")
-                .nextControlFlow("else if ($T.isNull(elB) || elB.isEmpty())", OBJECTS)
-                .addStatement("return elA")
-                .endControlFlow()
-                .addStatement("final $T combined = new $T(elA.size() + elB.size())", mutableTypeName, mutableTypeName)
-                .addStatement("combined.addAll(elA)")
-                .addStatement("combined.addAll(elB)");
+                final MethodSpec.Builder method = mergerStaticClass.createMethod(methodName, claimableOperation);
+                method.modifiers.clear();
+                method.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                    .addAnnotation(NULLABLE)
+                    .addParameter(paramA)
+                    .addParameter(paramB)
+                    .returns(paramTypeName)
+                    .addJavadoc("Merger for fields of class {@link $T}", targetTn)
+                    .beginControlFlow("if ($T.isNull(elA) || elA.isEmpty())", OBJECTS)
+                    .addStatement("return elB")
+                    .nextControlFlow("else if ($T.isNull(elB) || elB.isEmpty())", OBJECTS)
+                    .addStatement("return elA")
+                    .endControlFlow()
+                    .addStatement("final $T combined = new $T(elA.size() + elB.size())", mutableTypeName, mutableTypeName)
+                    .addStatement("combined.addAll(elA)")
+                    .addStatement("combined.addAll(elB)");
 
-            if (BuiltCollectionType.JAVA_IMMUTABLE.name().equals(builderOptionsPrism.builtCollectionType())) {
-                logTrace(method, "Returning merged collection - making immutable");
-                method.addStatement("return combined.stream().filter($T::nonNull).toList()", OBJECTS);
-            } else {
-                logTrace(method, "Returning merged collection - not making immutable");
-                method.addStatement("return combined");
+                if (BuiltCollectionType.JAVA_IMMUTABLE.name().equals(builderOptionsPrism.builtCollectionType())) {
+                    logTrace(method, "Returning merged collection - making immutable");
+                    method.addStatement("return combined.stream().filter($T::nonNull).toList()", OBJECTS);
+                } else {
+                    logTrace(method, "Returning merged collection - not making immutable");
+                    method.addStatement("return combined");
+                }
+        
+                AnnotationSupplier.addGeneratedAnnotation(method, this);
             }
-    
-            AnnotationSupplier.addGeneratedAnnotation(method, this);
+            
             return true;
 
         }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/collection/ListMerge.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/collection/ListMerge.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import javax.lang.model.element.Modifier;
 
 import io.avaje.spi.ServiceProvider;
-import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.BuiltCollectionType;
 import io.github.cbarlin.aru.core.AnnotationSupplier;
 import io.github.cbarlin.aru.core.impl.types.AnalysedCollectionComponent;
 import io.github.cbarlin.aru.core.types.AnalysedComponent;
@@ -80,15 +79,9 @@ public final class ListMerge extends MergerVisitor {
                     .endControlFlow()
                     .addStatement("final $T combined = new $T(elA.size() + elB.size())", mutableTypeName, mutableTypeName)
                     .addStatement("combined.addAll(elA)")
-                    .addStatement("combined.addAll(elB)");
-
-                if (BuiltCollectionType.JAVA_IMMUTABLE.name().equals(builderOptionsPrism.builtCollectionType())) {
-                    logTrace(method, "Returning merged collection - making immutable");
-                    method.addStatement("return combined.stream().filter($T::nonNull).toList()", OBJECTS);
-                } else {
-                    logTrace(method, "Returning merged collection - not making immutable");
-                    method.addStatement("return combined");
-                }
+                    .addStatement("combined.addAll(elB)")
+                    // Since this goes via the builder, that will handle things like immutability
+                    .addStatement("return combined");
         
                 AnnotationSupplier.addGeneratedAnnotation(method, this);
             }

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/visitors/AruVisitor.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/visitors/AruVisitor.java
@@ -118,6 +118,14 @@ public abstract class AruVisitor<T extends AnalysedType> implements Comparable<A
             .build();
     }
 
+    /**
+     * Converts a TypeName to a partial method name suitable for generating consistent
+     * method names across different visitors. Handles nested generics, arrays, and 
+     * strips annotations.
+     * 
+     * @param originalTypeName the TypeName to convert
+     * @return a string suitable for use in method names
+     */
     @SuppressWarnings({"java:S6880"}) // There is a ticket to make us work on Java 17 - let's not make more work for ourselves!
     protected static String typeNameToPartialMethodName(final TypeName originalTypeName) {
         if (originalTypeName.isAnnotated()) {
@@ -133,7 +141,7 @@ public abstract class AruVisitor<T extends AnalysedType> implements Comparable<A
         } else if (originalTypeName instanceof final ArrayTypeName atn) {
             return typeNameToPartialMethodName(atn.componentType) + "Arr";
         } else {
-            return originalTypeName.withoutAnnotations().toString();
+            return originalTypeName.toString();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,8 @@
         <vavr.version>0.10.7</vavr.version>
         <woodstox.version>7.1.1</woodstox.version>
         <xmlunit.version>2.10.3</xmlunit.version>
+        <rainbowgum.version>0.8.2</rainbowgum.version>
+        <tinylog.version>2.7.0</tinylog.version>
 
         <!-- Maven versions -->
         <central-publishing.version>0.8.0</central-publishing.version>
@@ -203,6 +205,21 @@
                 <version>${avaje-spi.version}</version>
                 <optional>true</optional>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.tinylog</groupId>
+                <artifactId>slf4j-tinylog</artifactId>
+                <version>${tinylog.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.tinylog</groupId>
+                <artifactId>tinylog-impl</artifactId>
+                <version>${tinylog.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jstach.rainbowgum</groupId>
+                <artifactId>rainbowgum</artifactId>
+                <version>${rainbowgum.version}</version>
             </dependency>
             <!-- to make dependabot check for latest maven version -->
             <dependency>

--- a/utils-tests/pom.xml
+++ b/utils-tests/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.github.cbarlin</groupId>
@@ -26,6 +28,7 @@
     <properties>
         <junit-bom.version>5.13.4</junit-bom.version>
         <rainbowgum.version>0.8.2</rainbowgum.version>
+        <tinylog.version>2.7.0</tinylog.version>
         <assertj.version>3.27.3</assertj.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
@@ -61,17 +64,6 @@
             <!-- Scope isn't needed here since this module and its children are not published -->
         </dependency>
         <dependency>
-            <groupId>io.jstach.rainbowgum</groupId>
-            <artifactId>rainbowgum-slf4j</artifactId>
-            <version>${rainbowgum.version}</version>
-        </dependency>
-        
-        <dependency>
-            <groupId>io.jstach.rainbowgum</groupId>
-            <artifactId>rainbowgum-pattern</artifactId>
-            <version>${rainbowgum.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
@@ -80,24 +72,47 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.jstach.rainbowgum</groupId>
-            <artifactId>rainbowgum</artifactId>
-            <version>${rainbowgum.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jstach.rainbowgum</groupId>
-            <artifactId>rainbowgum-core</artifactId>
-            <version>${rainbowgum.version}</version>
-            <scope>compile</scope>
-        </dependency>
+
         <dependency>
             <groupId>io.github.cbarlin</groupId>
             <artifactId>advanced-record-utils-annotations</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+    <!-- Start laying ground work for Java 17 support (issue #80) -->
+    <profiles>
+        <profile>
+            <id>jdk-17</id>
+            <activation>
+                <jdk>[17,21)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.tinylog</groupId>
+                    <artifactId>slf4j-tinylog</artifactId>
+                    <version>${tinylog.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.tinylog</groupId>
+                    <artifactId>tinylog-impl</artifactId>
+                    <version>${tinylog.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk-21-plus</id>
+            <activation>
+                <jdk>[21,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.jstach.rainbowgum</groupId>
+                    <artifactId>rainbowgum</artifactId>
+                    <version>${rainbowgum.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -115,7 +130,8 @@
                     <fork>true</fork>
                     <compilerArgs>
                         <arg>-J${jacoco.agent.argLine}</arg>
-                        <!-- <arg>-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005</arg> -->
+                        <!--
+                        <arg>-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005</arg> -->
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/utils-tests/pom.xml
+++ b/utils-tests/pom.xml
@@ -27,8 +27,6 @@
 
     <properties>
         <junit-bom.version>5.13.4</junit-bom.version>
-        <rainbowgum.version>0.8.2</rainbowgum.version>
-        <tinylog.version>2.7.0</tinylog.version>
         <assertj.version>3.27.3</assertj.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
@@ -79,10 +77,11 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+
     <!-- Start laying ground work for Java 17 support (issue #80) -->
     <profiles>
         <profile>
-            <id>jdk-17</id>
+            <id>jdk-17-to-20-inclusive</id>
             <activation>
                 <jdk>[17,21)</jdk>
             </activation>
@@ -90,12 +89,10 @@
                 <dependency>
                     <groupId>org.tinylog</groupId>
                     <artifactId>slf4j-tinylog</artifactId>
-                    <version>${tinylog.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.tinylog</groupId>
                     <artifactId>tinylog-impl</artifactId>
-                    <version>${tinylog.version}</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -108,7 +105,6 @@
                 <dependency>
                     <groupId>io.jstach.rainbowgum</groupId>
                     <artifactId>rainbowgum</artifactId>
-                    <version>${rainbowgum.version}</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -130,8 +126,7 @@
                     <fork>true</fork>
                     <compilerArgs>
                         <arg>-J${jacoco.agent.argLine}</arg>
-                        <!--
-                        <arg>-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005</arg> -->
+                        <!-- <arg>-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005</arg> -->
                     </compilerArgs>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Fixes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of static merger method generation to avoid duplicate methods for the same type.
  * Enhanced logic for generating static method names based on parameter types rather than names.
  * Added conditional dependency management in the build system to support Java 17+ environments.

* **Bug Fixes**
  * Prevented redundant merger methods from being generated for repeated types, ensuring cleaner and more efficient code generation.

* **Chores**
  * Updated and reformatted build configuration for better readability and compatibility with newer Java versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->