### PR TITLE
Add `setXToNull` option

### DIFF
--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.java
@@ -410,7 +410,17 @@ public @interface AdvancedRecordUtils {
         boolean nullReplacesNotNull() default true;
 
         /**
-         * Should the builder generate "setXToNull" type methods?
+         * Should the builder generate explicit {@code setXToNull()} methods?
+         * <p>
+         * Notes:
+         * <ul>
+         *   <li>Only generated for reference types (non-primitives).</li>
+         *   <li>When applied to collection components, this sets the builder field to {@code null};
+         *       the final built value may still be an empty collection if
+         *       {@link BuilderOptions#buildNullCollectionToEmpty()} is {@code true}.</li>
+         *   <li>This is orthogonal to {@link BuilderOptions#nullReplacesNotNull()} — calling
+         *       {@code setXToNull()} always sets the builder field to {@code null}.</li>
+         * </ul>
          */
         boolean setToNullMethods() default false;
 

--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.java
@@ -415,11 +415,11 @@ public @interface AdvancedRecordUtils {
          * Notes:
          * <ul>
          *   <li>Only generated for reference types (non-primitives).</li>
-         *   <li>When applied to collection components, this sets the builder field to {@code null};
-         *       the final built value may still be an empty collection if
-         *       {@link BuilderOptions#buildNullCollectionToEmpty()} is {@code true}.</li>
-         *   <li>This is orthogonal to {@link BuilderOptions#nullReplacesNotNull()} — calling
-         *       {@code setXToNull()} always sets the builder field to {@code null}.</li>
+         *   <li>For {@code Optional<T>} components, this sets the builder field to {@code Optional.empty()}.</li>
+         *   <li>For collection components, this sets the builder field to {@code null}; the final built value may still
+         *       be an empty collection if {@link #buildNullCollectionToEmpty()} is {@code true}.</li>
+         *   <li>Generation is **gated** by {@link #nullReplacesNotNull()}: when that option is {@code false},
+         *       {@code setXToNull()} methods are not generated.</li>
          * </ul>
          */
         boolean setToNullMethods() default false;

--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.java
@@ -410,6 +410,11 @@ public @interface AdvancedRecordUtils {
         boolean nullReplacesNotNull() default true;
 
         /**
+         * Should the builder generate "setXToNull" type methods?
+         */
+        boolean setToNullMethods() default false;
+
+        /**
          * What type of collection should be built?
          */
         BuiltCollectionType builtCollectionType() default BuiltCollectionType.JAVA_IMMUTABLE;

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
@@ -19,6 +19,7 @@ public enum Constants {
         public static final ClaimableOperation BUILDER_CONCRETE_OPTIONAL = new ClaimableOperation("builderConcreteSetterForOptional", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_FLUENT_SETTER = new ClaimableOperation("builderFluentSetter", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_SET_TIME_TO_NOW = new ClaimableOperation("builderSetTimeToNow", FIELD_AND_ACCESSORS);
+        public static final ClaimableOperation BUILDER_SET_TO_NULL = new ClaimableOperation("builderSetToNull", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_USE_TYPE_CONVERTER = new ClaimableOperation("builderUseTypeConverter", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation DIFFER_COLLECTION_RESULT = new ClaimableOperation("differCollectionResult", CLASS);
         public static final ClaimableOperation DIFFER_COMPUTE_CHANGE = new ClaimableOperation("differComputation", FIELD_AND_ACCESSORS);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/SetToNull.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/SetToNull.java
@@ -1,0 +1,56 @@
+package io.github.cbarlin.aru.impl.builder;
+
+import io.avaje.inject.Component;
+import io.avaje.inject.RequiresBean;
+import io.avaje.inject.RequiresProperty;
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.types.AnalysedRecord;
+import io.github.cbarlin.aru.core.types.components.ConstructorComponent;
+import io.github.cbarlin.aru.core.visitors.RecordVisitor;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.wiring.BuilderPerComponentScope;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+
+import javax.lang.model.element.Modifier;
+
+@Component
+@BuilderPerComponentScope
+@RequiresBean({ConstructorComponent.class})
+@RequiresProperty(value = "setToNullMethods", equalTo = "true")
+@RequiresProperty(value = "nullReplacesNotNull", equalTo = "true")
+public final class SetToNull extends RecordVisitor {
+
+    public SetToNull(final AnalysedRecord analysedRecord) {
+        super(Constants.Claims.BUILDER_SET_TO_NULL, analysedRecord);
+    }
+
+    @Override
+    public int specificity() {
+        return 1;
+    }
+
+    @Override
+    protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
+        if (analysedComponent.typeName().isPrimitive()) {
+            return false;
+        }
+        final String methodName = "set" + analysedComponent.nameFirstLetterCaps() + "ToNull";
+        final MethodSpec.Builder builder = analysedRecord.builderArtifact().createMethod(methodName, claimableOperation)
+            .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
+            .addStatement(
+                "this.$L = null",
+                analysedComponent.name()
+            )
+            .addStatement("return this")
+            .addAnnotation(Constants.Names.NON_NULL)
+            .addJavadoc(
+                "Sets the value of $L to null",
+                analysedComponent.name()
+            )
+            .returns(analysedRecord.builderArtifact().className());
+        AnnotationSupplier.addGeneratedAnnotation(builder, this);
+
+        return true;
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/SetToNullCollectionNeverNull.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/SetToNullCollectionNeverNull.java
@@ -34,9 +34,6 @@ public final class SetToNullCollectionNeverNull extends RecordVisitor {
 
     @Override
     protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
-        if (analysedComponent.typeName().isPrimitive()) {
-            return false;
-        }
         final String methodName = "set" + analysedComponent.nameFirstLetterCaps() + "ToNull";
         final MethodSpec.Builder builder = analysedRecord.builderArtifact().createMethod(methodName, claimableOperation)
             .addModifiers(Modifier.FINAL, Modifier.PUBLIC)

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/list/JustListCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/list/JustListCollectionHandler.java
@@ -19,13 +19,17 @@ public final class JustListCollectionHandler extends ListCollectionHandler {
 
     @Override
     protected void convertToImmutable(final MethodSpec.Builder methodBuilder, final String fieldName, final String targetVariableName, final TypeName innerTypeName) {
-        methodBuilder.addStatement(
-            "final $T<$T> $L = $L.stream()\n    .filter($T::nonNull)\n    .toList()",
-            immutableClassName,
-            innerTypeName,
-            targetVariableName,
-            fieldName,
-            OBJECTS
-        );
+        methodBuilder
+            .beginControlFlow("if ($T.isNull($L))", OBJECTS, fieldName)
+            .addStatement("return $T.of()", LIST)
+            .endControlFlow()
+            .addStatement(
+                "final $T<$T> $L = $L.stream()\n    .filter($T::nonNull)\n    .toList()",
+                immutableClassName,
+                innerTypeName,
+                targetVariableName,
+                fieldName,
+                OBJECTS
+            );
     }
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/JustSetOfEnumCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/JustSetOfEnumCollectionHandler.java
@@ -57,8 +57,8 @@ public final class JustSetOfEnumCollectionHandler extends SetCollectionHandler {
 
     @Override
     public void writeNonNullAutoGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        // Remember: these are explicitly not immutable.
         methodBuilder.returns(component.typeName())
-            .addComment("Usually you use Set.copyOf, but that internally uses a slower HashSet. This keeps the speed of an EnumSet, and maintains deep immutability by using a collection that can't be used elsewhere")
             .addStatement("final $T<$T> ___copy = $T.copyOf(this.$L)", ENUM_SET, innerType, ENUM_SET, component.name())
             .addStatement("return ___copy");
     }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/JustSetOfEnumCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/JustSetOfEnumCollectionHandler.java
@@ -60,11 +60,14 @@ public final class JustSetOfEnumCollectionHandler extends SetCollectionHandler {
         methodBuilder.returns(component.typeName())
             .addComment("Usually you use Set.copyOf, but that internally uses a slower HashSet. This keeps the speed of an EnumSet, and maintains deep immutability by using a collection that can't be used elsewhere")
             .addStatement("final $T<$T> ___copy = $T.copyOf(this.$L)", ENUM_SET, innerType, ENUM_SET, component.name())
-            .addStatement("return $T.unmodifiableSet(___copy)", COLLECTIONS);
+            .addStatement("return ___copy", COLLECTIONS);
     }
 
     @Override
     public void writeNonNullImmutableGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
-        writeNonNullAutoGetter(component, methodBuilder, innerType);
+        methodBuilder.returns(component.typeName())
+            .addComment("Usually you use Set.copyOf, but that internally uses a slower HashSet. This keeps the speed of an EnumSet, and maintains deep immutability by using a collection that can't be used elsewhere")
+            .addStatement("final $T<$T> ___copy = $T.copyOf(this.$L)", ENUM_SET, innerType, ENUM_SET, component.name())
+            .addStatement("return $T.unmodifiableSet(___copy)", COLLECTIONS);
     }
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/JustSetOfEnumCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/JustSetOfEnumCollectionHandler.java
@@ -60,7 +60,7 @@ public final class JustSetOfEnumCollectionHandler extends SetCollectionHandler {
         methodBuilder.returns(component.typeName())
             .addComment("Usually you use Set.copyOf, but that internally uses a slower HashSet. This keeps the speed of an EnumSet, and maintains deep immutability by using a collection that can't be used elsewhere")
             .addStatement("final $T<$T> ___copy = $T.copyOf(this.$L)", ENUM_SET, innerType, ENUM_SET, component.name())
-            .addStatement("return ___copy", COLLECTIONS);
+            .addStatement("return ___copy");
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/SetCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/SetCollectionHandler.java
@@ -1,6 +1,7 @@
 package io.github.cbarlin.aru.impl.types.collection.set;
 
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.COLLECTORS;
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.LIST;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.SET;
@@ -23,15 +24,19 @@ public abstract class SetCollectionHandler extends StandardCollectionHandler {
 
     @Override
     protected void convertToImmutable(final MethodSpec.Builder methodBuilder, final String fieldName, final String assignmentName, final TypeName innerTypeName) {
-        methodBuilder.addStatement(
-            "final $T<$T> $L = $L.stream()\n    .filter($T::nonNull)\n    .collect($T.toUnmodifiableSet())",
-            immutableClassName,
-            innerTypeName,
-            assignmentName,
-            fieldName,
-            OBJECTS,
-            COLLECTORS
-        );
+        methodBuilder
+            .beginControlFlow("if ($T.isNull($L))", OBJECTS, fieldName)
+            .addStatement("return $T.of()", SET)
+            .endControlFlow()
+            .addStatement(
+                "final $T<$T> $L = $L.stream()\n    .filter($T::nonNull)\n    .collect($T.toUnmodifiableSet())",
+                immutableClassName,
+                innerTypeName,
+                assignmentName,
+                fieldName,
+                OBJECTS,
+                COLLECTORS
+            );
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/SetCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/SetCollectionHandler.java
@@ -1,7 +1,6 @@
 package io.github.cbarlin.aru.impl.types.collection.set;
 
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.COLLECTORS;
-import static io.github.cbarlin.aru.core.CommonsConstants.Names.LIST;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.SET;

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/PropertyConfigLoader.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/PropertyConfigLoader.java
@@ -56,6 +56,7 @@ public final class PropertyConfigLoader implements ConfigPropertyPlugin {
                 case "fluent" -> Boolean.FALSE.equals(prism.builderOptions().fluent()) ? FALSE : TRUE;
                 case "concreteSettersForOptional" -> Boolean.FALSE.equals(prism.builderOptions().concreteSettersForOptional()) ? FALSE : TRUE;
                 case "nullReplacesNotNull" -> Boolean.FALSE.equals(prism.builderOptions().nullReplacesNotNull()) ? FALSE : TRUE;
+                case "buildNullCollectionToEmpty" -> Boolean.FALSE.equals(prism.builderOptions().buildNullCollectionToEmpty()) ? FALSE : TRUE;
                 // Default of false means `null` is false, so compare against true
                 case "setTimeNowMethods" -> Boolean.TRUE.equals(prism.builderOptions().setTimeNowMethods()) ? TRUE : FALSE;
                 case "setToNullMethods" -> Boolean.TRUE.equals(prism.builderOptions().setToNullMethods()) ? TRUE : FALSE;

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/PropertyConfigLoader.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/PropertyConfigLoader.java
@@ -55,8 +55,10 @@ public final class PropertyConfigLoader implements ConfigPropertyPlugin {
                 case "createAllInterface" -> Boolean.FALSE.equals(prism.createAllInterface()) ? FALSE : TRUE;
                 case "fluent" -> Boolean.FALSE.equals(prism.builderOptions().fluent()) ? FALSE : TRUE;
                 case "concreteSettersForOptional" -> Boolean.FALSE.equals(prism.builderOptions().concreteSettersForOptional()) ? FALSE : TRUE;
+                case "nullReplacesNotNull" -> Boolean.FALSE.equals(prism.builderOptions().nullReplacesNotNull()) ? FALSE : TRUE;
                 // Default of false means `null` is false, so compare against true
                 case "setTimeNowMethods" -> Boolean.TRUE.equals(prism.builderOptions().setTimeNowMethods()) ? TRUE : FALSE;
+                case "setToNullMethods" -> Boolean.TRUE.equals(prism.builderOptions().setToNullMethods()) ? TRUE : FALSE;
                 case "addJsonbImportAnnotation" -> Boolean.TRUE.equals(prism.addJsonbImportAnnotation()) ? TRUE : FALSE;
                 case "diffOptions.staticMethodsAddedToUtils" -> Boolean.TRUE.equals(prism.diffOptions().staticMethodsAddedToUtils()) ? TRUE : FALSE;
                 // String(-ish) properties

--- a/docs/generated-code/options/builder-generation-setnull.adoc
+++ b/docs/generated-code/options/builder-generation-setnull.adoc
@@ -1,0 +1,29 @@
+****
+
+.Generated code
+[%collapsible]
+=====
+[source,java]
+----
+public final class PersonUtils implements GeneratedUtil {
+    public static final class Builder {
+        public final Builder setNameToNull() {
+            this.name = null;
+            return this;
+        }
+
+        public final Builder setOffsetDateTimeToNull() {
+            this.offsetDateTime = null;
+            return this;
+        }
+
+        public final Builder setTagsToNull() {
+            this.tags.clear();
+            return this;
+        }
+    }
+}
+----
+=====
+
+****

--- a/docs/options/aru-builder/generation.adoc
+++ b/docs/options/aru-builder/generation.adoc
@@ -257,32 +257,34 @@ include::../../generated-code/options/builder-generation-settime.adoc[]
 .`+setToNullMethods+`
 [%collapsible]
 ====
-Should the builder contain methods that allow you to set a field to:
+Should the builder generate methods to explicitly reset a field to a “null-like” state?
 
-* Empty, for `+Optional+` type component
-* Empty, for collection components if `+buildNullCollectionToEmpty+` is `+true+`
-* `+null+` in all other cases
+* Empty for `+Optional+` components
+* Empty for collection components when `+buildNullCollectionToEmpty+` is `+true+`
+* `+null+` for all other component types
 
 *Type*:: `+boolean+`
 *Default*:: `+false+`
+
+.CAUTION
+When `nullReplacesNotNull = false`, these `setXToNull` methods will not be generated at all.
 
 .Usage
 [source,java]
 ----
 @AdvancedRecordUtils(
-    builderOptions = @BuilderOptions(
-        setToNullMethods = true
+    builderOptions = @AdvancedRecordUtils.BuilderOptions(
+        setToNullMethods      = true
     )
 )
 public record Person(
     OffsetDateTime offsetDateTime,
-    ZonedDateTime zonedDateTime,
-    LocalDateTime localDateTime
-) {
-}
+    List<String> tags,
+    String name
+) { }
 ----
 
-include::../../generated-code/options/builder-generation-settime.adoc[]
+include::../../generated-code/options/builder-generation-setnull.adoc[]
 
 ====
 

--- a/docs/options/aru-builder/generation.adoc
+++ b/docs/options/aru-builder/generation.adoc
@@ -257,24 +257,26 @@ include::../../generated-code/options/builder-generation-settime.adoc[]
 .`+setToNullMethods+`
 [%collapsible]
 ====
+
 Should the builder generate methods to explicitly reset a field to a “null-like” state?
 
-* Empty for `+Optional+` components
-* Empty for collection components when `+buildNullCollectionToEmpty+` is `+true+`
-* `+null+` for all other component types
+The result of the method is:
+
+* empty for `+Optional+` components
+* empty for collection components when `+buildNullCollectionToEmpty+` is `+true+`
+* `+null+` for all other component types.
 
 *Type*:: `+boolean+`
 *Default*:: `+false+`
 
-.CAUTION
-When `nullReplacesNotNull = false`, these `setXToNull` methods will not be generated at all.
+CAUTION: When `nullReplacesNotNull = false`, these `setXToNull` methods will not be generated at all.
 
 .Usage
 [source,java]
 ----
 @AdvancedRecordUtils(
     builderOptions = @AdvancedRecordUtils.BuilderOptions(
-        setToNullMethods      = true
+        setToNullMethods = true
     )
 )
 public record Person(

--- a/docs/options/aru-builder/generation.adoc
+++ b/docs/options/aru-builder/generation.adoc
@@ -254,6 +254,38 @@ include::../../generated-code/options/builder-generation-settime.adoc[]
 
 ====
 
+.`+setToNullMethods+`
+[%collapsible]
+====
+Should the builder contain methods that allow you to set a field to:
+
+* Empty, for `+Optional+` type component
+* Empty, for collection components if `+buildNullCollectionToEmpty+` is `+true+`
+* `+null+` in all other cases
+
+*Type*:: `+boolean+`
+*Default*:: `+false+`
+
+.Usage
+[source,java]
+----
+@AdvancedRecordUtils(
+    builderOptions = @BuilderOptions(
+        setToNullMethods = true
+    )
+)
+public record Person(
+    OffsetDateTime offsetDateTime,
+    ZonedDateTime zonedDateTime,
+    LocalDateTime localDateTime
+) {
+}
+----
+
+include::../../generated-code/options/builder-generation-settime.adoc[]
+
+====
+
 .`+concreteSettersForOptional+`
 [%collapsible]
 ====

--- a/utils-tests/a_core_dependency/src/test/java/io/github/cbarlin/aru/tests/a_core_dependency/BasicBuildTest.java
+++ b/utils-tests/a_core_dependency/src/test/java/io/github/cbarlin/aru/tests/a_core_dependency/BasicBuildTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class BasicBuildTest {
 
@@ -26,6 +27,10 @@ class BasicBuildTest {
         assertNull(someInterface.bItem().recursionFtw().woo());
         assertNull(someInterface.bItem().recursionFtw().otherItem().someStringField());
         assertNull(someInterface.bItem().woo().someStringField());
+
+        assertThrows(NoSuchMethodException.class, () -> {
+            MyRecordCUtils.Builder.class.getDeclaredMethod("setBItemToNull");
+        }, "Method 'setBItemToNull' should not be declared on the builder.");
     }
 
     @Test

--- a/utils-tests/b_type_alias/src/test/java/io/github/cbarlin/aru/tests/b_types_alias/BuilderTests.java
+++ b/utils-tests/b_type_alias/src/test/java/io/github/cbarlin/aru/tests/b_types_alias/BuilderTests.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class BuilderTests {
 
@@ -25,6 +26,14 @@ class BuilderTests {
         assertEquals("And this is a book", someRecord.bookName().value());
         assertEquals(69, someRecord.randomIntB().value());
         assertEquals(13, someRecord.randomIntC().value());
+
+        assertThrows(NoSuchMethodException.class, () -> {
+            SomeRecordUtils.Builder.class.getDeclaredMethod("another");
+        }, "Method 'another' should not be declared on the builder.");
+
+        assertThrows(NoSuchMethodException.class, () -> {
+            SomeRecordUtils.Builder.class.getDeclaredMethod("another", String.class);
+        }, "Method 'another' should not be declared on the builder.");
     }
     
     @Test

--- a/utils-tests/c_deeply_nested_structure/src/main/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/SeventhLevelA.java
+++ b/utils-tests/c_deeply_nested_structure/src/main/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/SeventhLevelA.java
@@ -1,7 +1,13 @@
 package io.github.cbarlin.aru.tests.c_deeply_nested_structure;
 
+import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
 import jakarta.xml.bind.annotation.XmlElement;
 
+@AdvancedRecordUtils(
+    builderOptions = @AdvancedRecordUtils.BuilderOptions(
+        setToNullMethods = true
+    )
+)
 public record SeventhLevelA(
     @XmlElement
     RecurringReference andImDone

--- a/utils-tests/c_deeply_nested_structure/src/main/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/ThirdLevelBFromA.java
+++ b/utils-tests/c_deeply_nested_structure/src/main/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/ThirdLevelBFromA.java
@@ -1,7 +1,26 @@
 package io.github.cbarlin.aru.tests.c_deeply_nested_structure;
 
+import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
 import jakarta.xml.bind.annotation.XmlAttribute;
 
+@AdvancedRecordUtils(
+    diffable = true,
+    addJsonbImportAnnotation = true,
+    logGeneration = AdvancedRecordUtils.LoggingGeneration.SLF4J_GENERATED_UTIL_INTERFACE,
+    diffOptions = @AdvancedRecordUtils.DiffOptions(staticMethodsAddedToUtils = true),
+    builderOptions = @AdvancedRecordUtils.BuilderOptions(
+        builtCollectionType = AdvancedRecordUtils.BuiltCollectionType.JAVA_IMMUTABLE,
+        setTimeNowMethodSuffix = "ToCurrent",
+        buildMethodName = "make",
+        setTimeNowMethodPrefix = "update",
+        setToNullMethods = true
+    ),
+    xmlable = true,
+    witherOptions = @AdvancedRecordUtils.WitherOptions(convertToBuilder = "toBuilder"),
+    createAllInterface = true,
+    wither = true,
+    merger = true
+)
 public record ThirdLevelBFromA(
     @XmlAttribute
     int someValue

--- a/utils-tests/c_deeply_nested_structure/src/test/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/NestedTests.java
+++ b/utils-tests/c_deeply_nested_structure/src/test/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/NestedTests.java
@@ -61,6 +61,9 @@ class NestedTests {
                                 five -> five.nowToSix(
                                     six -> six.woo(
                                         seven -> seven
+                                            // This is set to null (proving the method exists)
+                                            //  and then immediately overridden.
+                                            // The override is tested via the XML check
                                             .setAndImDoneToNull()
                                             .andImDone(
                                                 recurringAgain -> recurringAgain.itemA("Hi!")

--- a/utils-tests/c_deeply_nested_structure/src/test/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/NestedTests.java
+++ b/utils-tests/c_deeply_nested_structure/src/test/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/NestedTests.java
@@ -1,6 +1,7 @@
 package io.github.cbarlin.aru.tests.c_deeply_nested_structure;
 
 import io.avaje.jsonb.Jsonb;
+import io.github.cbarlin.aru.tests.a_core_dependency.MyRecordCUtils;
 import io.github.cbarlin.aru.tests.xml_util.ConvertToXml;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +13,7 @@ import java.time.ZoneOffset;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class NestedTests {
@@ -58,9 +60,11 @@ class NestedTests {
                             four -> four.letsGoFive(
                                 five -> five.nowToSix(
                                     six -> six.woo(
-                                        seven -> seven.andImDone(
-                                            recurringAgain -> recurringAgain.itemA("Hi!")
-                                        )
+                                        seven -> seven
+                                            .setAndImDoneToNull()
+                                            .andImDone(
+                                                recurringAgain -> recurringAgain.itemA("Hi!")
+                                            )
                                     )
                                 )
                             )
@@ -95,6 +99,14 @@ class NestedTests {
         assertThat(result)
             .isNotNull()
             .isNotBlank();
+    }
+
+    @Test
+    void setXToNullMethodDetection() {
+        var m = assertDoesNotThrow(
+            () -> SeventhLevelAUtils.Builder.class.getDeclaredMethod("setAndImDoneToNull")
+        );
+        assertNotNull(m);
     }
 
     @Test

--- a/utils-tests/c_deeply_nested_structure/src/test/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/NestedTests.java
+++ b/utils-tests/c_deeply_nested_structure/src/test/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/NestedTests.java
@@ -107,6 +107,10 @@ class NestedTests {
             () -> SeventhLevelAUtils.Builder.class.getDeclaredMethod("setAndImDoneToNull")
         );
         assertNotNull(m);
+        // This shouldn't be generated because the component is a primitive
+        assertThrows(NoSuchMethodException.class, () -> {
+            ThirdLevelBFromAUtils.Builder.class.getDeclaredMethod("setSomeValueToNull");
+        }, "Method 'setSomeValueToNull' should not be declared on the builder.");
     }
 
     @Test

--- a/utils-tests/c_deeply_nested_structure/src/test/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/NestedTests.java
+++ b/utils-tests/c_deeply_nested_structure/src/test/java/io/github/cbarlin/aru/tests/c_deeply_nested_structure/NestedTests.java
@@ -1,7 +1,6 @@
 package io.github.cbarlin.aru.tests.c_deeply_nested_structure;
 
 import io.avaje.jsonb.Jsonb;
-import io.github.cbarlin.aru.tests.a_core_dependency.MyRecordCUtils;
 import io.github.cbarlin.aru.tests.xml_util.ConvertToXml;
 import org.junit.jupiter.api.Test;
 

--- a/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NonNullableAutoCollectionBag.java
+++ b/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NonNullableAutoCollectionBag.java
@@ -29,6 +29,12 @@ import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.XmlOptions;
         inferXmlElementName = NameGeneration.MATCH
     ),
     merger = true,
+    mergerOptions = @AdvancedRecordUtils.MergerOptions(
+        staticMethodsAddedToUtils = true
+    ),
+    diffOptions = @AdvancedRecordUtils.DiffOptions(
+        staticMethodsAddedToUtils = true
+    ),
     wither = true
 )
 public record NonNullableAutoCollectionBag(

--- a/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NonNullableImmutableCollectionBag.java
+++ b/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NonNullableImmutableCollectionBag.java
@@ -23,11 +23,17 @@ import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.XmlOptions;
         // buildNullCollectionToEmpty = true
     ),
     diffable = true,
+    diffOptions = @AdvancedRecordUtils.DiffOptions(
+        staticMethodsAddedToUtils = true
+    ),
     xmlable = true,
     xmlOptions = @XmlOptions(
         inferXmlElementName = NameGeneration.MATCH
     ),
     merger = true,
+    mergerOptions = @AdvancedRecordUtils.MergerOptions(
+        staticMethodsAddedToUtils = true
+    ),
     wither = true
 )
 public record NonNullableImmutableCollectionBag(

--- a/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NullableAutoCollectionBag.java
+++ b/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NullableAutoCollectionBag.java
@@ -28,6 +28,12 @@ import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.XmlOptions;
         inferXmlElementName = NameGeneration.MATCH
     ),
     merger = true,
+    mergerOptions = @AdvancedRecordUtils.MergerOptions(
+        staticMethodsAddedToUtils = true
+    ),
+    diffOptions = @AdvancedRecordUtils.DiffOptions(
+        staticMethodsAddedToUtils = true
+    ),
     wither = true
 )
 public record NullableAutoCollectionBag(

--- a/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NullableImmutableCollectionBag.java
+++ b/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NullableImmutableCollectionBag.java
@@ -28,6 +28,12 @@ import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.XmlOptions;
         inferXmlElementName = NameGeneration.MATCH
     ),
     merger = true,
+    mergerOptions = @AdvancedRecordUtils.MergerOptions(
+        staticMethodsAddedToUtils = true
+    ),
+    diffOptions = @AdvancedRecordUtils.DiffOptions(
+        staticMethodsAddedToUtils = true
+    ),
     wither = true
 )
 public record NullableImmutableCollectionBag(

--- a/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/OddTypeBag.java
+++ b/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/OddTypeBag.java
@@ -22,10 +22,15 @@ import java.util.UUID;
     merger = true,
     wither = true,
     xmlable = true,
-    xmlOptions = @XmlOptions(inferXmlElementName = NameGeneration.UPPER_FIRST_LETTER),
+    xmlOptions = @XmlOptions(
+        inferXmlElementName = NameGeneration.UPPER_FIRST_LETTER
+    ),
     createAllInterface = true,
     logGeneration = LoggingGeneration.SLF4J_GENERATED_UTIL_INTERFACE,
-    attemptToFindExistingUtils = true
+    attemptToFindExistingUtils = true,
+    builderOptions = @AdvancedRecordUtils.BuilderOptions(
+        setToNullMethods = true
+    )
 )
 public record OddTypeBag(
     @XmlElementWrapper(name = "WrapperOfLSO")

--- a/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/CollectionsTests.java
+++ b/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/CollectionsTests.java
@@ -1,0 +1,481 @@
+package io.github.cbarlin.aru.tests.c_odd_types;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CollectionsTests {
+
+    @Test
+    void nonNullImmTest() {
+        final NonNullableImmutableCollectionBag a = NonNullableImmutableCollectionBagUtils.builder()
+            .build();
+        // All of these should not be null
+        assertNotNull(a.setOfEnum());
+        assertNotNull(a.enumSetOfEnum());
+        assertNotNull(a.hashSetOfEnum());
+        assertNotNull(a.treeSetOfEnum());
+        assertNotNull(a.sortedSetOfEnum());
+        assertNotNull(a.setOfString());
+        assertNotNull(a.hashSetOfString());
+        assertNotNull(a.treeSetOfString());
+        assertNotNull(a.sortedSetOfString());
+        assertNotNull(a.listOfString());
+        assertNotNull(a.arrayListOfString());
+        assertNotNull(a.linkedListOfString());
+        assertNotNull(a.vectorOfString());
+        assertNotNull(a.stackOfString());
+        // And the "generic" ("Set", "List") ones should not permit me to add to them
+        assertThrows(UnsupportedOperationException.class, () -> a.setOfEnum().add(AnEnum.ONE));
+        assertThrows(UnsupportedOperationException.class, () -> a.setOfString().add("A"));
+        assertThrows(UnsupportedOperationException.class, () -> a.listOfString().add("A"));
+
+        // Even if I explicitly set one to null, I should get a non-null output
+        final NonNullableImmutableCollectionBag b = NonNullableImmutableCollectionBagUtils.builder()
+            .setOfEnum(null)
+            .build();
+        assertNotNull(b.setOfEnum());
+
+        // OK, lets try and do a diff
+        final NonNullableImmutableCollectionBag c = NonNullableImmutableCollectionBagUtils.builder()
+            .addEnumSetOfEnum(AnEnum.TWO)
+            .addHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
+            .addTreeSetOfString("This is a string!")
+            .addLinkedListOfString(Stream.of("A").iterator())
+            .addLinkedListOfString(Stream.of("A").spliterator())
+            .addStackOfString(List.of("A"))
+            .build();
+        final var diff = NonNullableImmutableCollectionBagUtils.diff(b, c);
+        assertFalse(diff.hasSetOfEnumChanged(), "setOfEnum");
+        assertTrue(diff.hasEnumSetOfEnumChanged(), "enumSetOfEnum");
+        assertTrue(diff.hasHashSetOfEnumChanged(), "hashSetOfEnum");
+        assertFalse(diff.hasTreeSetOfEnumChanged(), "treeSetOfEnum");
+        assertFalse(diff.hasSortedSetOfEnumChanged(), "sortedSetOfEnum");
+        assertFalse(diff.hasSetOfStringChanged(), "setOfString");
+        assertFalse(diff.hasHashSetOfStringChanged(), "hashSetOfString");
+        assertTrue(diff.hasTreeSetOfStringChanged(), "treeSetOfString");
+        assertFalse(diff.hasSortedSetOfStringChanged(), "sortedSetOfString");
+        assertFalse(diff.hasListOfStringChanged(), "listOfString");
+        assertFalse(diff.hasArrayListOfStringChanged(), "arrayListOfString");
+        assertTrue(diff.hasLinkedListOfStringChanged(), "linkedListOfString");
+        assertFalse(diff.hasVectorOfStringChanged(), "vectorOfString");
+        assertTrue(diff.hasStackOfStringChanged(), "stackOfString");
+
+        assertThat(diff.diffEnumSetOfEnum().addedElements())
+            .isUnmodifiable()
+            .hasSize(1)
+            .containsExactly(AnEnum.TWO);
+
+        assertThat(diff.diffEnumSetOfEnum().elementsInCommon())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffEnumSetOfEnum().removedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().addedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().elementsInCommon())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().removedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffStackOfString().addedElements())
+            .isUnmodifiable()
+            .hasSize(1)
+            .containsExactly("A");
+
+        assertThat(diff.diffLinkedListOfString().addedElements())
+            .isUnmodifiable()
+            .hasSize(2)
+            .containsExactly("A", "A");
+
+        // Let's merge two instances together!
+        final NonNullableImmutableCollectionBag d = NonNullableImmutableCollectionBagUtils.merge(
+            c,
+            NonNullableImmutableCollectionBagUtils.builder()
+                .addSetOfEnum(AnEnum.ONE)
+                .addLinkedListOfString("B")
+                .build()
+        );
+
+        assertNotNull(d);
+
+        assertThat(d.setOfEnum())
+            .isNotNull()
+            .isUnmodifiable()
+            .hasSize(1)
+            .containsExactly(AnEnum.ONE);
+
+        assertThat(d.enumSetOfEnum())
+            .isNotNull()
+            .hasSameElementsAs(c.enumSetOfEnum());
+
+        assertThat(d.linkedListOfString())
+            .isNotNull()
+            .hasSize(3)
+            .containsExactly("A", "A", "B");
+    }
+
+    @Test
+    void nonNullAutoTest() {
+        final NonNullableAutoCollectionBag a = NonNullableAutoCollectionBagUtils.builder()
+            .build();
+        // All of these should not be null
+        assertNotNull(a.setOfEnum());
+        assertNotNull(a.enumSetOfEnum());
+        assertNotNull(a.hashSetOfEnum());
+        assertNotNull(a.treeSetOfEnum());
+        assertNotNull(a.sortedSetOfEnum());
+        assertNotNull(a.setOfString());
+        assertNotNull(a.hashSetOfString());
+        assertNotNull(a.treeSetOfString());
+        assertNotNull(a.sortedSetOfString());
+        assertNotNull(a.listOfString());
+        assertNotNull(a.arrayListOfString());
+        assertNotNull(a.linkedListOfString());
+        assertNotNull(a.vectorOfString());
+        assertNotNull(a.stackOfString());
+        // And the "generic" ("Set", "List") ones should not permit me to add to them
+        assertThat(a.setOfEnum())
+            .isInstanceOf(EnumSet.class);
+        assertThat(a.setOfString())
+            .isInstanceOf(HashSet.class);
+        assertThat(a.listOfString())
+            .isInstanceOf(ArrayList.class);
+
+        // Even if I explicitly set one to null, I should get a non-null output
+        final NonNullableAutoCollectionBag b = NonNullableAutoCollectionBagUtils.builder()
+            .setOfEnum(null)
+            .build();
+        assertNotNull(b.setOfEnum());
+
+        // OK, lets try and do a diff
+        final NonNullableAutoCollectionBag c = NonNullableAutoCollectionBagUtils.builder()
+            .addEnumSetOfEnum(AnEnum.TWO)
+            .addHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
+            .addTreeSetOfString("This is a string!")
+            .addLinkedListOfString(Stream.of("A").iterator())
+            .addLinkedListOfString(Stream.of("A").spliterator())
+            .addStackOfString(List.of("A"))
+            .build();
+        final var diff = NonNullableAutoCollectionBagUtils.diff(b, c);
+        assertFalse(diff.hasSetOfEnumChanged(), "setOfEnum");
+        assertTrue(diff.hasEnumSetOfEnumChanged(), "enumSetOfEnum");
+        assertTrue(diff.hasHashSetOfEnumChanged(), "hashSetOfEnum");
+        assertFalse(diff.hasTreeSetOfEnumChanged(), "treeSetOfEnum");
+        assertFalse(diff.hasSortedSetOfEnumChanged(), "sortedSetOfEnum");
+        assertFalse(diff.hasSetOfStringChanged(), "setOfString");
+        assertFalse(diff.hasHashSetOfStringChanged(), "hashSetOfString");
+        assertTrue(diff.hasTreeSetOfStringChanged(), "treeSetOfString");
+        assertFalse(diff.hasSortedSetOfStringChanged(), "sortedSetOfString");
+        assertFalse(diff.hasListOfStringChanged(), "listOfString");
+        assertFalse(diff.hasArrayListOfStringChanged(), "arrayListOfString");
+        assertTrue(diff.hasLinkedListOfStringChanged(), "linkedListOfString");
+        assertFalse(diff.hasVectorOfStringChanged(), "vectorOfString");
+        assertTrue(diff.hasStackOfStringChanged(), "stackOfString");
+
+        assertThat(diff.diffEnumSetOfEnum().addedElements())
+            .isUnmodifiable()
+            .hasSize(1)
+            .containsExactly(AnEnum.TWO);
+
+        assertThat(diff.diffEnumSetOfEnum().elementsInCommon())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffEnumSetOfEnum().removedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().addedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().elementsInCommon())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().removedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffStackOfString().addedElements())
+            .isUnmodifiable()
+            .hasSize(1)
+            .containsExactly("A");
+
+        assertThat(diff.diffLinkedListOfString().addedElements())
+            .isUnmodifiable()
+            .hasSize(2)
+            .containsExactly("A", "A");
+
+        // Let's merge two instances together!
+        final NonNullableAutoCollectionBag d = NonNullableAutoCollectionBagUtils.merge(
+            c,
+            NonNullableAutoCollectionBagUtils.builder()
+                .addSetOfEnum(AnEnum.ONE)
+                .addLinkedListOfString("B")
+                .build()
+        );
+
+        assertNotNull(d);
+
+        assertThat(d.setOfEnum())
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(AnEnum.ONE);
+
+        assertThat(d.enumSetOfEnum())
+            .isNotNull()
+            .hasSameElementsAs(c.enumSetOfEnum());
+
+        assertThat(d.linkedListOfString())
+            .isNotNull()
+            .hasSize(3)
+            .containsExactly("A", "A", "B");
+    }
+
+    @Test
+    void nlImmTest() {
+        final NullableImmutableCollectionBag a = NullableImmutableCollectionBagUtils.builder()
+            .build();
+        // All of these should be null!
+        assertNull(a.setOfEnum());
+        assertNull(a.enumSetOfEnum());
+        assertNull(a.hashSetOfEnum());
+        assertNull(a.treeSetOfEnum());
+        assertNull(a.sortedSetOfEnum());
+        assertNull(a.setOfString());
+        assertNull(a.hashSetOfString());
+        assertNull(a.treeSetOfString());
+        assertNull(a.sortedSetOfString());
+        assertNull(a.listOfString());
+        assertNull(a.arrayListOfString());
+        assertNull(a.linkedListOfString());
+        assertNull(a.vectorOfString());
+        assertNull(a.stackOfString());
+        // If I try and add something though, it should be non-modifiable
+        final NullableImmutableCollectionBag b = NullableImmutableCollectionBagUtils.builder()
+            .addSetOfEnum(AnEnum.ONE)
+            .build();
+        assertThat(b.setOfEnum())
+            .isNotNull()
+            .isUnmodifiable()
+            .hasSize(1)
+            .containsExactly(AnEnum.ONE);
+
+        // OK, lets try and do a diff
+        final NullableImmutableCollectionBag c = NullableImmutableCollectionBagUtils.builder()
+            .addEnumSetOfEnum(AnEnum.TWO)
+            .addHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
+            .addTreeSetOfString("This is a string!")
+            .addLinkedListOfString(Stream.of("A").iterator())
+            .addLinkedListOfString(Stream.of("A").spliterator())
+            .addStackOfString(List.of("A"))
+            .build();
+        final var diff = NullableImmutableCollectionBagUtils.diff(a, c);
+        assertFalse(diff.hasSetOfEnumChanged(), "setOfEnum");
+        assertTrue(diff.hasEnumSetOfEnumChanged(), "enumSetOfEnum");
+        assertTrue(diff.hasHashSetOfEnumChanged(), "hashSetOfEnum");
+        assertFalse(diff.hasTreeSetOfEnumChanged(), "treeSetOfEnum");
+        assertFalse(diff.hasSortedSetOfEnumChanged(), "sortedSetOfEnum");
+        assertFalse(diff.hasSetOfStringChanged(), "setOfString");
+        assertFalse(diff.hasHashSetOfStringChanged(), "hashSetOfString");
+        assertTrue(diff.hasTreeSetOfStringChanged(), "treeSetOfString");
+        assertFalse(diff.hasSortedSetOfStringChanged(), "sortedSetOfString");
+        assertFalse(diff.hasListOfStringChanged(), "listOfString");
+        assertFalse(diff.hasArrayListOfStringChanged(), "arrayListOfString");
+        assertTrue(diff.hasLinkedListOfStringChanged(), "linkedListOfString");
+        assertFalse(diff.hasVectorOfStringChanged(), "vectorOfString");
+        assertTrue(diff.hasStackOfStringChanged(), "stackOfString");
+
+        assertThat(diff.diffEnumSetOfEnum().addedElements())
+            .isUnmodifiable()
+            .hasSize(1)
+            .containsExactly(AnEnum.TWO);
+
+        assertThat(diff.diffEnumSetOfEnum().elementsInCommon())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffEnumSetOfEnum().removedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().addedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().elementsInCommon())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().removedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffStackOfString().addedElements())
+            .isUnmodifiable()
+            .hasSize(1)
+            .containsExactly("A");
+
+        assertThat(diff.diffLinkedListOfString().addedElements())
+            .isUnmodifiable()
+            .hasSize(2)
+            .containsExactly("A", "A");
+
+        // Let's merge two instances together!
+        final NullableImmutableCollectionBag d = NullableImmutableCollectionBagUtils.merge(
+            c,
+            NullableImmutableCollectionBagUtils.builder()
+                .addSetOfEnum(AnEnum.ONE)
+                .addLinkedListOfString("B")
+                .build()
+        );
+
+        assertNotNull(d);
+
+        assertThat(d.setOfEnum())
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(AnEnum.ONE);
+
+        assertThat(d.enumSetOfEnum())
+            .isNotNull()
+            .hasSameElementsAs(c.enumSetOfEnum());
+
+        assertThat(d.linkedListOfString())
+            .isNotNull()
+            .hasSize(3)
+            .containsExactly("A", "A", "B");
+    }
+
+    @Test
+    void nlAutoTest() {
+        final NullableAutoCollectionBag a = NullableAutoCollectionBagUtils.builder()
+            .build();
+        // All of these should be null!
+        assertNull(a.setOfEnum());
+        assertNull(a.enumSetOfEnum());
+        assertNull(a.hashSetOfEnum());
+        assertNull(a.treeSetOfEnum());
+        assertNull(a.sortedSetOfEnum());
+        assertNull(a.setOfString());
+        assertNull(a.hashSetOfString());
+        assertNull(a.treeSetOfString());
+        assertNull(a.sortedSetOfString());
+        assertNull(a.listOfString());
+        assertNull(a.arrayListOfString());
+        assertNull(a.linkedListOfString());
+        assertNull(a.vectorOfString());
+        assertNull(a.stackOfString());
+        // If I try and add something though it should be an EnumSet!
+        final NullableAutoCollectionBag b = NullableAutoCollectionBagUtils.builder()
+            .addSetOfEnum(AnEnum.ONE)
+            .build();
+        assertThat(b.setOfEnum())
+            .isInstanceOf(EnumSet.class)
+            .hasSize(1)
+            .containsExactly(AnEnum.ONE);
+
+        // OK, lets try and do a diff
+        final NullableAutoCollectionBag c = NullableAutoCollectionBagUtils.builder()
+            .addEnumSetOfEnum(AnEnum.TWO)
+            .addHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
+            .addTreeSetOfString("This is a string!")
+            .addLinkedListOfString(Stream.of("A").iterator())
+            .addLinkedListOfString(Stream.of("A").spliterator())
+            .addStackOfString(List.of("A"))
+            .build();
+        final var diff = NullableAutoCollectionBagUtils.diff(a, c);
+        assertFalse(diff.hasSetOfEnumChanged(), "setOfEnum");
+        assertTrue(diff.hasEnumSetOfEnumChanged(), "enumSetOfEnum");
+        assertTrue(diff.hasHashSetOfEnumChanged(), "hashSetOfEnum");
+        assertFalse(diff.hasTreeSetOfEnumChanged(), "treeSetOfEnum");
+        assertFalse(diff.hasSortedSetOfEnumChanged(), "sortedSetOfEnum");
+        assertFalse(diff.hasSetOfStringChanged(), "setOfString");
+        assertFalse(diff.hasHashSetOfStringChanged(), "hashSetOfString");
+        assertTrue(diff.hasTreeSetOfStringChanged(), "treeSetOfString");
+        assertFalse(diff.hasSortedSetOfStringChanged(), "sortedSetOfString");
+        assertFalse(diff.hasListOfStringChanged(), "listOfString");
+        assertFalse(diff.hasArrayListOfStringChanged(), "arrayListOfString");
+        assertTrue(diff.hasLinkedListOfStringChanged(), "linkedListOfString");
+        assertFalse(diff.hasVectorOfStringChanged(), "vectorOfString");
+        assertTrue(diff.hasStackOfStringChanged(), "stackOfString");
+
+        assertThat(diff.diffEnumSetOfEnum().addedElements())
+            .isUnmodifiable()
+            .hasSize(1)
+            .containsExactly(AnEnum.TWO);
+
+        assertThat(diff.diffEnumSetOfEnum().elementsInCommon())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffEnumSetOfEnum().removedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().addedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().elementsInCommon())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffVectorOfString().removedElements())
+            .isUnmodifiable()
+            .isEmpty();
+
+        assertThat(diff.diffStackOfString().addedElements())
+            .isUnmodifiable()
+            .hasSize(1)
+            .containsExactly("A");
+
+        assertThat(diff.diffLinkedListOfString().addedElements())
+            .isUnmodifiable()
+            .hasSize(2)
+            .containsExactly("A", "A");
+
+        // Let's merge two instances together!
+        final NullableAutoCollectionBag d = NullableAutoCollectionBagUtils.merge(
+            c,
+            NullableAutoCollectionBagUtils.builder()
+                .addSetOfEnum(AnEnum.ONE)
+                .addLinkedListOfString("B")
+                .build()
+        );
+
+        assertNotNull(d);
+
+        assertThat(d.setOfEnum())
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(AnEnum.ONE);
+
+        assertThat(d.enumSetOfEnum())
+            .isNotNull()
+            .hasSameElementsAs(c.enumSetOfEnum());
+
+        assertThat(d.linkedListOfString())
+            .isNotNull()
+            .hasSize(3)
+            .containsExactly("A", "A", "B");
+    }
+}

--- a/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/TypesTests.java
+++ b/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/TypesTests.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,6 +43,23 @@ class TypesTests {
         assertThrows(NoSuchMethodException.class, () -> {
             OddTypeBagUtils.Builder.class.getDeclaredMethod("thisShouldNotBeInTheBuilder", String.class);
         }, "Method 'thisShouldNotBeInTheBuilder' should not be declared on the builder.");
+    }
+
+    // This tests that Optionals and Collections handle the "setToNull" methods correctly
+    @Test
+    void setToNull() {
+        final OddTypeBag bag = assertDoesNotThrow(
+            () -> OddTypeBagUtils.builder()
+                .addMoreOptionalInts(OptionalInt.of(1))
+                .someOptional("Hi there!")
+                .setMoreOptionalIntsToNull()
+                .setSomeOptionalToNull()
+                .build()
+        );
+        assertNotNull(bag.someOptional());
+        assertTrue(bag.someOptional().isEmpty());
+        assertNotNull(bag.moreOptionalInts());
+        assertTrue(bag.moreOptionalInts().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Fixes #91. Also added tests for the collections, which caused a change to enum output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added builder option setToNullMethods (default false) to generate setXToNull methods; supports null-to-empty collection variant when configured.
- Bug Fixes
  - Guarded conversions to avoid NPEs for null Lists/Sets.
  - Clarified Set<Enum> getters: auto getter returns a mutable copy; immutable getter returns an unmodifiable view.
- Documentation
  - Added docs and examples for setToNullMethods.
- Tests
  - Expanded collection, diff/merge and setXToNull tests; added reflection-based presence/absence checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->