### PR TITLE
Add MapStruct support and optional integration with validating builds

### DIFF
--- a/advanced-record-utils-annotations/pom.xml
+++ b/advanced-record-utils-annotations/pom.xml
@@ -38,6 +38,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <optional>true</optional>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <optional>true</optional>

--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.java
@@ -469,6 +469,18 @@ public @interface AdvancedRecordUtils {
          * Should we generate an overload for optional types that accepts the concrete one?
          */
         boolean concreteSettersForOptional() default true;
+
+        /**
+         * If both:
+         * <ul>
+         *     <li>You have {@link #validatedBuilder()} set to {@code AVAJE}; and</li>
+         *     <li>You are using MapStruct</li>
+         * </ul>
+         * <p>
+         * Then setting this to {@code true} will make MapStruct use the default Avaje validator to
+         *   validate the mapped object
+         */
+        boolean mapStructValidatesWithAvaje() default false;
     }
 
     /**

--- a/advanced-record-utils-processor/pom.xml
+++ b/advanced-record-utils-processor/pom.xml
@@ -39,6 +39,12 @@
             <groupId>io.avaje</groupId>
             <artifactId>avaje-inject</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <optional>true</optional>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/AruMapStructBuilderProvider.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/AruMapStructBuilderProvider.java
@@ -25,7 +25,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -81,6 +80,16 @@ public final class AruMapStructBuilderProvider implements BuilderProvider {
             case AnalysedType at -> at.className();
         };
         final String buildMethodName = processingTarget.prism().builderOptions().buildMethodName();
+        if (Boolean.TRUE.equals(processingTarget.prism().builderOptions().mapStructValidatesWithAvaje())) {
+            final List<ExecutableElement> validateMethod = findPublicBuildMethodsWithName(buildMethodName + "AndValidate", builderClass, target);
+            if (!validateMethod.isEmpty()) {
+                return validateMethod;
+            }
+        }
+        return findPublicBuildMethodsWithName(buildMethodName, builderClass, target);
+    }
+
+    private static List<ExecutableElement> findPublicBuildMethodsWithName(final String buildMethodName, final TypeElement builderClass, final TypeName target) {
         for (final ExecutableElement e : ElementFilter.methodsIn(builderClass.getEnclosedElements())) {
             if (
                 e.getParameters().isEmpty()

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/AruMapStructBuilderProvider.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/AruMapStructBuilderProvider.java
@@ -22,6 +22,17 @@ import javax.lang.model.util.ElementFilter;
 import java.util.Collection;
 import java.util.Optional;
 
+/**
+ * SPI into MapStruct that allows it to use our builders. To do this, we need to:
+ * <ul>
+ *     <li>Have written the builder (since MapStruct needs the finished {@link ExecutableElement} objects)</li>
+ *     <li>Find the constructor for the builder and add it to MapStruct's {@link BuilderInfo.Builder#builderCreationMethod(ExecutableElement)}</li>
+ *     <li>Find the "finish" method on the builder and add it to MapStruct's {@link BuilderInfo.Builder#buildMethod(Collection)}</li>
+ * </ul>
+ * <p>
+ * We can hint to the MapStruct processor (which uses this class) that it needs to wait to the next processing round
+ *   by throwing an {@link TypeHierarchyErroneousException} containing the requested {@link TypeMirror}
+ */
 @ServiceProvider(BuilderProvider.class)
 public final class AruMapStructBuilderProvider implements BuilderProvider {
 
@@ -30,6 +41,7 @@ public final class AruMapStructBuilderProvider implements BuilderProvider {
     public BuilderInfo findBuilderInfo(final TypeMirror typeMirror) {
         final UtilsProcessingContext context = obtainContext(typeMirror);
         final Optional<ProcessingTarget> target = context.analysedType(typeMirror);
+
         if (target.isPresent()) {
             // Excellent, we can use this!
             return createBuilderInfo(typeMirror, target.get());

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/AruMapStructBuilderProvider.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/AruMapStructBuilderProvider.java
@@ -11,17 +11,20 @@ import io.github.cbarlin.aru.core.types.LibraryLoadedTarget;
 import io.github.cbarlin.aru.core.types.ProcessingTarget;
 import io.github.cbarlin.aru.prism.prison.AdvancedRecordUtilsPrism;
 import io.micronaut.sourcegen.javapoet.TypeName;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mapstruct.ap.spi.BuilderInfo;
 import org.mapstruct.ap.spi.BuilderProvider;
 import org.mapstruct.ap.spi.TypeHierarchyErroneousException;
 
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -43,10 +46,7 @@ public final class AruMapStructBuilderProvider implements BuilderProvider {
 
     @Override
     @Nullable
-    public BuilderInfo findBuilderInfo(final @Nullable TypeMirror typeMirror) {
-        if (Objects.isNull(typeMirror)) {
-            return null;
-        }
+    public BuilderInfo findBuilderInfo(final @NonNull TypeMirror typeMirror) {
         final UtilsProcessingContext context = obtainContext(typeMirror);
         final Optional<ProcessingTarget> target = context.analysedType(typeMirror);
 
@@ -63,13 +63,10 @@ public final class AruMapStructBuilderProvider implements BuilderProvider {
     }
 
     private static BuilderInfo createBuilderInfo(final TypeMirror typeMirror, final ProcessingTarget processingTarget) {
-        final Optional<TypeElement> optUtilsClass = Optional.ofNullable(APContext.elements().getTypeElement(processingTarget.utilsClassName().canonicalName()));
-        final Optional<TypeElement> optBuilderClass = Optional.ofNullable(APContext.elements().getTypeElement(processingTarget.builderArtifact().className().canonicalName()));
-        if (optUtilsClass.isEmpty() || optBuilderClass.isEmpty()) {
-            throw new TypeHierarchyErroneousException(typeMirror);
-        }
-        final TypeElement utilsClass = optUtilsClass.get();
-        final TypeElement builderClass = optBuilderClass.get();
+        final TypeElement utilsClass = Optional.ofNullable(APContext.elements().getTypeElement(processingTarget.utilsClassName().canonicalName()))
+            .orElseThrow(() -> new TypeHierarchyErroneousException(typeMirror));
+        final TypeElement builderClass = Optional.ofNullable(APContext.elements().getTypeElement(processingTarget.builderArtifact().className().canonicalName()))
+            .orElseThrow(() -> new TypeHierarchyErroneousException(typeMirror));
         return (new BuilderInfo.Builder())
             .buildMethod(buildMethods(builderClass, processingTarget))
             // MapStruct has handlers for null
@@ -84,20 +81,25 @@ public final class AruMapStructBuilderProvider implements BuilderProvider {
             case AnalysedType at -> at.className();
         };
         final String buildMethodName = processingTarget.prism().builderOptions().buildMethodName();
-        return ElementFilter.methodsIn(builderClass.getEnclosedElements())
-            .stream()
-            .filter(e -> e.getParameters().isEmpty())
-            .filter(e -> OptionalClassDetector.checkSameOrSubType(TypeName.get(e.getReturnType()), target))
-            .filter(e -> e.getSimpleName().toString().equals(buildMethodName))
-            .toList();
+        for (final ExecutableElement e : ElementFilter.methodsIn(builderClass.getEnclosedElements())) {
+            if (
+                e.getParameters().isEmpty()
+                    && e.getModifiers().contains(Modifier.PUBLIC)
+                    && e.getSimpleName().toString().equals(buildMethodName)
+                    && OptionalClassDetector.checkSameOrSubType(TypeName.get(e.getReturnType()), target)
+            ) {
+                return List.of(e);
+            }
+        }
+        return List.of();
     }
 
     @Nullable
     private static ExecutableElement builderCreator(final TypeElement utilsClass, final ProcessingTarget processingTarget) {
         final String creationMethodName = processingTarget.prism().builderOptions().emptyCreationName();
         final TypeName builderClassName = processingTarget.builderArtifact().className();
-        final var enclosedElements = utilsClass.getEnclosedElements();
-        final var methods = ElementFilter.methodsIn(enclosedElements);
+        final List<? extends Element> enclosedElements = utilsClass.getEnclosedElements();
+        final List<ExecutableElement> methods = ElementFilter.methodsIn(enclosedElements);
         for (final ExecutableElement method : methods) {
             if (
                 method.getSimpleName().toString().equals(creationMethodName)
@@ -113,13 +115,10 @@ public final class AruMapStructBuilderProvider implements BuilderProvider {
     }
 
     private static UtilsProcessingContext obtainContext(final TypeMirror typeMirror) {
-        final Optional<UtilsProcessingContext> optionalContext = AdvRecUtilsProcessor.globalBeanScope()
+        return AdvRecUtilsProcessor.globalBeanScope()
             .flatMap(beanScope -> beanScope.getOptional(UtilsProcessingContext.class))
-            .filter(UtilsProcessingContext::hasPerformedAnalysis);
-        if (optionalContext.isEmpty()) {
-            throw new TypeHierarchyErroneousException(typeMirror);
-        }
-        return optionalContext.get();
+            .filter(UtilsProcessingContext::hasPerformedAnalysis)
+            .orElseThrow(() -> new TypeHierarchyErroneousException(typeMirror));
     }
 
     private static boolean annotationPresent(final TypeMirror typeMirror) {

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/AruMapStructBuilderProvider.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/AruMapStructBuilderProvider.java
@@ -1,0 +1,104 @@
+package io.github.cbarlin.aru.impl;
+
+import io.avaje.spi.ServiceProvider;
+import io.github.cbarlin.aru.core.APContext;
+import io.github.cbarlin.aru.core.AdvRecUtilsProcessor;
+import io.github.cbarlin.aru.core.OptionalClassDetector;
+import io.github.cbarlin.aru.core.UtilsProcessingContext;
+import io.github.cbarlin.aru.core.types.AnalysedType;
+import io.github.cbarlin.aru.core.types.LibraryLoadedTarget;
+import io.github.cbarlin.aru.core.types.ProcessingTarget;
+import io.github.cbarlin.aru.prism.prison.AdvancedRecordUtilsPrism;
+import io.micronaut.sourcegen.javapoet.TypeName;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.ap.spi.BuilderInfo;
+import org.mapstruct.ap.spi.BuilderProvider;
+import org.mapstruct.ap.spi.TypeHierarchyErroneousException;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import java.util.Collection;
+import java.util.Optional;
+
+@ServiceProvider(BuilderProvider.class)
+public final class AruMapStructBuilderProvider implements BuilderProvider {
+
+    @Override
+    @Nullable
+    public BuilderInfo findBuilderInfo(final TypeMirror typeMirror) {
+        final UtilsProcessingContext context = obtainContext(typeMirror);
+        final Optional<ProcessingTarget> target = context.analysedType(typeMirror);
+        if (target.isPresent()) {
+            // Excellent, we can use this!
+            return createBuilderInfo(typeMirror, target.get());
+        }
+
+        if (annotationPresent(typeMirror)) {
+            throw new TypeHierarchyErroneousException(typeMirror);
+        }
+
+        return null;
+    }
+
+    private static BuilderInfo createBuilderInfo(final TypeMirror typeMirror, final ProcessingTarget processingTarget) {
+        final Optional<TypeElement> optUtilsClass = Optional.ofNullable(APContext.elements().getTypeElement(processingTarget.utilsClassName().canonicalName()));
+        final Optional<TypeElement> optBuilderClass = Optional.ofNullable(APContext.elements().getTypeElement(processingTarget.builderArtifact().className().canonicalName()));
+        if (optUtilsClass.isEmpty() || optBuilderClass.isEmpty()) {
+            throw new TypeHierarchyErroneousException(typeMirror);
+        }
+        final TypeElement utilsClass = optUtilsClass.get();
+        final TypeElement builderClass = optBuilderClass.get();
+        return (new BuilderInfo.Builder())
+            .buildMethod(buildMethods(builderClass, processingTarget))
+            .builderCreationMethod(builderCreator(utilsClass, processingTarget))
+            .build();
+    }
+
+    private static Collection<ExecutableElement> buildMethods(final TypeElement builderClass, final ProcessingTarget processingTarget) {
+        final TypeName target = switch (processingTarget) {
+            case LibraryLoadedTarget llt -> llt.intendedType();
+            case AnalysedType at -> at.className();
+        };
+        final String buildMethodName = processingTarget.prism().builderOptions().buildMethodName();
+        return ElementFilter.methodsIn(builderClass.getEnclosedElements())
+            .stream()
+            .filter(e -> e.getParameters().isEmpty())
+            .filter(e -> target.equals(TypeName.get(e.getReturnType())))
+            .filter(e -> e.getSimpleName().toString().equals(buildMethodName))
+            .toList();
+    }
+
+    @Nullable
+    private static ExecutableElement builderCreator(final TypeElement utilsClass, final ProcessingTarget processingTarget) {
+        final String creationMethodName = processingTarget.prism().builderOptions().emptyCreationName();
+        final TypeName builderClassName = processingTarget.builderArtifact().className();
+        final var enclosedElements = utilsClass.getEnclosedElements();
+        final var methods = ElementFilter.methodsIn(enclosedElements);
+        for (final ExecutableElement method : methods) {
+            if (method.getSimpleName().toString().equals(creationMethodName) && method.getParameters().isEmpty() && TypeName.get(method.getReturnType()).equals(builderClassName)) {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    private static UtilsProcessingContext obtainContext(final TypeMirror typeMirror) {
+        final Optional<UtilsProcessingContext> optionalContext = AdvRecUtilsProcessor.globalBeanScope()
+            .flatMap(beanScope -> beanScope.getOptional(UtilsProcessingContext.class))
+            .filter(UtilsProcessingContext::hasPerformedAnalysis);
+        if (optionalContext.isEmpty()) {
+            throw new TypeHierarchyErroneousException(typeMirror);
+        }
+        final UtilsProcessingContext context = optionalContext.get();
+        return context;
+    }
+
+    private boolean annotationPresent(final TypeMirror typeMirror) {
+        return OptionalClassDetector.optionalDependencyTypeElement(typeMirror)
+            .filter(AdvancedRecordUtilsPrism::isPresent)
+            .isPresent();
+    }
+
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddAdder.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddAdder.java
@@ -62,7 +62,7 @@ public final class AddAdder extends CollectionRecordVisitor {
             .addAnnotation(CommonsConstants.Names.NON_NULL)
             .addModifiers(Modifier.PUBLIC);
 
-        if (minimalCollectionHandler.nullReplacesNonNull()) {
+        if (minimalCollectionHandler.nullReplacesNotNull()) {
             method.addJavadoc("\n<p>\n")
                 .addJavadoc("Supplying a null value will set the current value to null");
         } else {

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddSetter.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddSetter.java
@@ -46,7 +46,7 @@ public final class AddSetter extends CollectionRecordVisitor {
         final MethodSpec.Builder method = builderClass
             .createMethod(name, claimableOperation, analysedCollectionComponent.element());
 
-        populateStartOfMethod(analysedCollectionComponent, method, minimalCollectionHandler.nullReplacesNonNull(), name);
+        populateStartOfMethod(analysedCollectionComponent, method, minimalCollectionHandler.nullReplacesNotNull(), name);
         minimalCollectionHandler.writeSetter(method);
 
         method.addStatement("return this");
@@ -55,7 +55,7 @@ public final class AddSetter extends CollectionRecordVisitor {
         return true;
     }
 
-    private void populateStartOfMethod(final AnalysedCollectionComponent ac, final MethodSpec.Builder method, final boolean nullReplacesNonNull, final String name) {
+    private void populateStartOfMethod(final AnalysedCollectionComponent ac, final MethodSpec.Builder method, final boolean nullReplacesNotNull, final String name) {
         final ParameterSpec param = ParameterSpec.builder(ac.typeName(), name, Modifier.FINAL)
             .addJavadoc("The replacement value")
             .addAnnotation(NULLABLE)
@@ -67,7 +67,7 @@ public final class AddSetter extends CollectionRecordVisitor {
             .addAnnotation(CommonsConstants.Names.NON_NULL)
             .addModifiers(Modifier.PUBLIC);
         
-        if (nullReplacesNonNull) {
+        if (nullReplacesNotNull) {
             method.addJavadoc("\n<p>\n")
                 .addJavadoc("Supplying a null value will set the current value to null/empty");
         } else {

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/validation/AvajeValidatedBuild.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/validation/AvajeValidatedBuild.java
@@ -1,25 +1,37 @@
 package io.github.cbarlin.aru.impl.builder.validation;
 
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.NON_NULL;
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
 import static io.github.cbarlin.aru.impl.Constants.Names.AVAJE_CONSTRAINT_VIOLATION;
 import static io.github.cbarlin.aru.impl.Constants.Names.AVAJE_VALIDATOR;
+import static io.github.cbarlin.aru.impl.Constants.Names.JAKARTA_VALIDATOR;
+import static io.github.cbarlin.aru.impl.Constants.Names.OBJECTS;
 
 import javax.lang.model.element.Modifier;
 
 import io.avaje.inject.Component;
 import io.avaje.inject.RequiresProperty;
 import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.CommonsConstants;
 import io.github.cbarlin.aru.core.types.AnalysedRecord;
 import io.github.cbarlin.aru.core.visitors.RecordVisitor;
 import io.github.cbarlin.aru.impl.Constants.Claims;
 import io.github.cbarlin.aru.impl.wiring.BuilderPerRecordScope;
+import io.micronaut.sourcegen.javapoet.ArrayTypeName;
+import io.micronaut.sourcegen.javapoet.ClassName;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
 import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
+import io.micronaut.sourcegen.javapoet.WildcardTypeName;
 
 @Component
 @BuilderPerRecordScope
 @RequiresProperty(value = "validatedBuilder", equalTo = "AVAJE")
 public final class AvajeValidatedBuild extends RecordVisitor {
+
+    private static final ParameterizedTypeName CLAZZ_PARAM = ParameterizedTypeName.get(ClassName.get(Class.class), WildcardTypeName.subtypeOf(TypeName.OBJECT));
+    private static final TypeName CLAZZ_ANY = ArrayTypeName.of(CLAZZ_PARAM);
 
     public AvajeValidatedBuild(final AnalysedRecord analysedRecord) {
         super(Claims.BUILDER_ADD_VALIDATED_BUILD_METHOD, analysedRecord);
@@ -33,8 +45,31 @@ public final class AvajeValidatedBuild extends RecordVisitor {
     @Override
     protected boolean visitStartOfClassImpl() {
         final String methodName = analysedRecord.settings().prism().builderOptions().buildMethodName();
+        validatePassedInWithGroups(methodName);
+        validateDefaultWithGroups(methodName);
+        return true;
+    }
 
-        // Start with the one that accepts the argument
+    private void validateDefaultWithGroups(final String methodName) {
+        final MethodSpec.Builder nArgsBuilder = analysedRecord.builderArtifact()
+            .createMethod(methodName + "AndValidate", claimableOperation, CLAZZ_PARAM)
+            .addException(AVAJE_CONSTRAINT_VIOLATION)
+            .returns(analysedRecord.intendedType())
+            .addParameter(
+                ParameterSpec.builder(CLAZZ_ANY, "groups", Modifier.FINAL)
+                    .addJavadoc("The groups targeted for validation")
+                    .addAnnotation(NULLABLE)
+                    .build()
+            )
+            .varargs(true)
+            .addJavadoc("Creates a new instance of {@link $T} from the fields set on this builder, validating the result.\n<p>\nUses the default validator", analysedRecord.intendedType())
+            .addAnnotation(NON_NULL)
+            .addStatement("return this.$L($T.builder().build(), groups)", methodName, AVAJE_VALIDATOR);
+
+        AnnotationSupplier.addGeneratedAnnotation(nArgsBuilder, this);
+    }
+
+    private void validatePassedInWithGroups(final String methodName) {
         final MethodSpec.Builder argedBuilder = analysedRecord.builderArtifact()
             .createMethod(methodName, claimableOperation, AVAJE_VALIDATOR)
             .addException(AVAJE_CONSTRAINT_VIOLATION)
@@ -44,25 +79,20 @@ public final class AvajeValidatedBuild extends RecordVisitor {
             .addParameter(
                 ParameterSpec.builder(AVAJE_VALIDATOR, "validator", Modifier.FINAL)
                     .addJavadoc("The validator to use")
+                    .addAnnotation(NON_NULL)
                     .build()
             )
+            .addParameter(
+                ParameterSpec.builder(CLAZZ_ANY, "groups", Modifier.FINAL)
+                    .addJavadoc("The groups targeted for validation")
+                    .addAnnotation(NULLABLE)
+                    .build()
+            )
+            .varargs(true)
             .addStatement("final $T built = this.$L()", analysedRecord.intendedType(), methodName)
-            .addStatement("validator.validate(built)", AVAJE_VALIDATOR)
+            .addStatement("validator.validate(built, groups)", AVAJE_VALIDATOR)
             .addStatement("return built");
         AnnotationSupplier.addGeneratedAnnotation(argedBuilder, this);
-
-        // Then the no-args version
-        final MethodSpec.Builder nArgsBuilder = analysedRecord.builderArtifact()
-            .createMethod(methodName + "AndValidate", claimableOperation, AVAJE_CONSTRAINT_VIOLATION)
-            .addException(AVAJE_CONSTRAINT_VIOLATION)
-            .returns(analysedRecord.intendedType())
-            .addJavadoc("Creates a new instance of {@link $T} from the fields set on this builder, validating the result.\n<p>\nUses the default validator", analysedRecord.intendedType())
-            .addAnnotation(NON_NULL)
-            .addStatement("return this.$L($T.builder().build())", methodName, AVAJE_VALIDATOR);
-
-        AnnotationSupplier.addGeneratedAnnotation(nArgsBuilder, this);
-
-        return true;
     }
 
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/CollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/CollectionHandler.java
@@ -59,7 +59,7 @@ public abstract class CollectionHandler {
      * <p>
      * Does not write returns or params
      */
-    public abstract void writeNullableAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNonNull);
+    public abstract void writeNullableAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNotNull);
 
     /**
      * Write an "add" method in the builder that is nullable and inherits the type passed to it
@@ -102,7 +102,7 @@ public abstract class CollectionHandler {
      * <p>
      * Does not write returns or params
      */
-    public abstract void writeNullableImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNonNull);
+    public abstract void writeNullableImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNotNull);
 
     /**
      * Write an "add" method in the builder that is nullable and results in an immutable result
@@ -145,7 +145,7 @@ public abstract class CollectionHandler {
      * <p>
      * Does not write returns or params
      */
-    public abstract void writeNonNullAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNonNull);
+    public abstract void writeNonNullAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNotNull);
 
     /**
      * Write the "add" method in the builder that is never nullable, but inherits the type passed to it
@@ -189,7 +189,7 @@ public abstract class CollectionHandler {
      * <p>
      * Does not write returns or params
      */
-    public abstract void writeNonNullImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNonNull);
+    public abstract void writeNonNullImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNotNull);
 
     /**
      * Write the "add" method in the builder that is never nullable and results in an immutable result

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/CollectionHandlerHelper.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/CollectionHandlerHelper.java
@@ -23,7 +23,7 @@ public sealed interface CollectionHandlerHelper permits
     NullableImmutableCollectionHandler
 {
 
-    boolean nullReplacesNonNull();
+    boolean nullReplacesNotNull();
 
     /**
      * The component this is working with

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/CollectionHandlerHelperFactory.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/CollectionHandlerHelperFactory.java
@@ -36,16 +36,16 @@ public final class CollectionHandlerHelperFactory {
     private CollectionHandlerHelper createHandler(final AnalysedCollectionComponent ac, final CollectionHandler handler, final BuilderOptionsPrism opts) {
         final boolean nonNull = !Boolean.FALSE.equals(opts.buildNullCollectionToEmpty());
         final boolean immutable = !"AUTO".equals(opts.builtCollectionType());
-        final boolean nullReplacesNonNull = (!Boolean.FALSE.equals(opts.nullReplacesNotNull()));
+        final boolean nullReplacesNotNull = (!Boolean.FALSE.equals(opts.nullReplacesNotNull()));
 
         if (nonNull && immutable) {
-            return new NonNullImmutableNullCollectionHandler(ac, handler, nullReplacesNonNull);
+            return new NonNullImmutableNullCollectionHandler(ac, handler, nullReplacesNotNull);
         } else if (nonNull) {
-            return new NonNullAutoCollectionHandler(ac, handler, nullReplacesNonNull);
+            return new NonNullAutoCollectionHandler(ac, handler, nullReplacesNotNull);
         } else if (immutable) {
-            return new NullableImmutableCollectionHandler(ac, handler, nullReplacesNonNull);
+            return new NullableImmutableCollectionHandler(ac, handler, nullReplacesNotNull);
         } else {
-            return new NullableAutoCollectionHandler(ac, handler, nullReplacesNonNull);
+            return new NullableAutoCollectionHandler(ac, handler, nullReplacesNotNull);
         }
     }
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/StandardCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/StandardCollectionHandler.java
@@ -48,8 +48,8 @@ public abstract class StandardCollectionHandler extends CollectionHandler {
     }
 
     @Override
-    public void writeNullableAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNonNull) {
-        if (nullReplacesNonNull) {
+    public void writeNullableAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNotNull) {
+        if (nullReplacesNotNull) {
             methodBuilder.addStatement("this.$L = $L", component.name(), component.name());
         } else {
             methodBuilder.addStatement("this.$L = $T.nonNull($L) ? $L : this.$L", component.name(), OBJECTS, component.name(), component.name(), component.name());
@@ -58,8 +58,8 @@ public abstract class StandardCollectionHandler extends CollectionHandler {
     }
 
     @Override
-    public void writeNullableImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNonNull) {
-        writeNullableAutoSetter(component, methodBuilder, innerType, nullReplacesNonNull);
+    public void writeNullableImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNotNull) {
+        writeNullableAutoSetter(component, methodBuilder, innerType, nullReplacesNotNull);
     }
 
     @Override
@@ -120,8 +120,8 @@ public abstract class StandardCollectionHandler extends CollectionHandler {
     }
 
     @Override
-    public void writeNonNullAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNonNull) {
-        if (nullReplacesNonNull) {
+    public void writeNonNullAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNotNull) {
+        if (nullReplacesNotNull) {
             methodBuilder.addStatement("this.$L.clear()", component.name())
                 .beginControlFlow("if ($T.nonNull($L))", OBJECTS, component.name())
                 .addStatement("this.$L.addAll($L)", component.name(), component.name())
@@ -151,8 +151,8 @@ public abstract class StandardCollectionHandler extends CollectionHandler {
     }
 
     @Override
-    public void writeNonNullImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNonNull) {
-        writeNonNullAutoSetter(component, methodBuilder, innerType, nullReplacesNonNull);
+    public void writeNonNullImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType, final boolean nullReplacesNotNull) {
+        writeNonNullAutoSetter(component, methodBuilder, innerType, nullReplacesNotNull);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/eclipse/EclipseCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/eclipse/EclipseCollectionHandler.java
@@ -37,8 +37,8 @@ public sealed abstract class EclipseCollectionHandler extends StandardCollection
     }
 
     @Override
-    public void writeNonNullAutoSetter(AnalysedComponent component, MethodSpec.Builder methodBuilder, TypeName innerType, boolean nullReplacesNonNull) {
-        if (nullReplacesNonNull) {
+    public void writeNonNullAutoSetter(AnalysedComponent component, MethodSpec.Builder methodBuilder, TypeName innerType, boolean nullReplacesNotNull) {
+        if (nullReplacesNotNull) {
             methodBuilder.addStatement("this.$L.clear()", component.name())
                     .beginControlFlow("if ($T.nonNull($L))", OBJECTS, component.name())
                     .addStatement("this.$L.addAllIterable($L)", component.name(), component.name())

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NonNullAutoCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NonNullAutoCollectionHandler.java
@@ -14,7 +14,7 @@ import io.micronaut.sourcegen.javapoet.MethodSpec.Builder;
 public record NonNullAutoCollectionHandler(
     AnalysedCollectionComponent component,
     CollectionHandler handler,
-    boolean nullReplacesNonNull
+    boolean nullReplacesNotNull
 ) implements CollectionHandlerHelper {
 
     @Override
@@ -29,7 +29,7 @@ public record NonNullAutoCollectionHandler(
 
     @Override
     public void writeSetter(Builder methodBuilder) {
-        handler.writeNonNullAutoSetter(component, methodBuilder, component.unNestedPrimaryTypeName(), nullReplacesNonNull);
+        handler.writeNonNullAutoSetter(component, methodBuilder, component.unNestedPrimaryTypeName(), nullReplacesNotNull);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NonNullImmutableNullCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NonNullImmutableNullCollectionHandler.java
@@ -14,7 +14,7 @@ import io.micronaut.sourcegen.javapoet.MethodSpec.Builder;
 public record NonNullImmutableNullCollectionHandler(
     AnalysedCollectionComponent component,
     CollectionHandler handler,
-    boolean nullReplacesNonNull
+    boolean nullReplacesNotNull
 ) implements CollectionHandlerHelper {
 
     @Override
@@ -29,7 +29,7 @@ public record NonNullImmutableNullCollectionHandler(
 
     @Override
     public void writeSetter(Builder methodBuilder) {
-        handler.writeNonNullImmutableSetter(component, methodBuilder, component.unNestedPrimaryTypeName(), nullReplacesNonNull);
+        handler.writeNonNullImmutableSetter(component, methodBuilder, component.unNestedPrimaryTypeName(), nullReplacesNotNull);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NullableAutoCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NullableAutoCollectionHandler.java
@@ -14,7 +14,7 @@ import io.micronaut.sourcegen.javapoet.MethodSpec.Builder;
 public record NullableAutoCollectionHandler(
     AnalysedCollectionComponent component,
     CollectionHandler handler,
-    boolean nullReplacesNonNull
+    boolean nullReplacesNotNull
 ) implements CollectionHandlerHelper {
 
     @Override
@@ -29,7 +29,7 @@ public record NullableAutoCollectionHandler(
 
     @Override
     public void writeSetter(Builder methodBuilder) {
-        handler.writeNullableAutoSetter(component, methodBuilder, component.unNestedPrimaryTypeName(), nullReplacesNonNull);
+        handler.writeNullableAutoSetter(component, methodBuilder, component.unNestedPrimaryTypeName(), nullReplacesNotNull);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NullableImmutableCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NullableImmutableCollectionHandler.java
@@ -14,7 +14,7 @@ import io.micronaut.sourcegen.javapoet.MethodSpec.Builder;
 public record NullableImmutableCollectionHandler(
     AnalysedCollectionComponent component,
     CollectionHandler handler,
-    boolean nullReplacesNonNull
+    boolean nullReplacesNotNull
 ) implements CollectionHandlerHelper {
 
     @Override
@@ -29,7 +29,7 @@ public record NullableImmutableCollectionHandler(
 
     @Override
     public void writeSetter(Builder methodBuilder) {
-        handler.writeNullableImmutableSetter(component, methodBuilder, component.unNestedPrimaryTypeName(), nullReplacesNonNull);
+        handler.writeNullableImmutableSetter(component, methodBuilder, component.unNestedPrimaryTypeName(), nullReplacesNotNull);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/module-info.java
+++ b/advanced-record-utils-processor/src/main/java/module-info.java
@@ -24,7 +24,11 @@ module io.github.cbarlin.aru.worker {
 
     requires static io.avaje.spi;
     requires static org.jspecify;
+    requires static org.mapstruct.processor;
 
     provides io.github.cbarlin.aru.core.wiring.InjectModuleFinder with
         io.github.cbarlin.aru.impl.wiring.InjectModuleProvider;
+
+    provides org.mapstruct.ap.spi.BuilderProvider with
+        io.github.cbarlin.aru.impl.AruMapStructBuilderProvider;
 }

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/AdvRecUtilsProcessor.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/AdvRecUtilsProcessor.java
@@ -55,7 +55,7 @@ public final class AdvRecUtilsProcessor extends AbstractProcessor {
             AdvRecUtilsProcessor.globalBeanScope = BeanScopeFactory.loadGlobalScope(processingEnvironment);
         }
 
-        // Rebuild if we're invoked with a different ProcessingEnvironment (Gradle daemon / multi‐module safety)
+        // Rebuild if we're invoked with a different ProcessingEnvironment (Gradle daemon / multi-module safety)
         final ProcessingEnvironment currentEnv = globalBeanScope.get(ProcessingEnvironment.class);
         if (currentEnv != processingEnvironment) {
             try {

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/UtilsProcessingContext.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/UtilsProcessingContext.java
@@ -26,6 +26,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -56,8 +57,17 @@ public final class UtilsProcessingContext {
         return APContext.processingEnv();
     }
 
+    public boolean hasPerformedAnalysis() {
+        return !this.analysedTypes.isEmpty();
+    }
+
     public @Nullable ProcessingTarget analysedType(final TypeElement typeElement) {
         return analysedTypes.get(typeElement);
+    }
+
+    public Optional<ProcessingTarget> analysedType(final TypeMirror typeMirror) {
+        return OptionalClassDetector.optionalDependencyTypeElement(typeMirror)
+            .map(this::analysedType);
     }
 
     public Optional<List<AnalysedTypeConverter>> obtainConverters(final TypeName typeName) {

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/artifacts/ToBeBuilt.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/artifacts/ToBeBuilt.java
@@ -235,7 +235,7 @@ public abstract sealed class ToBeBuilt implements GenerationArtifact<ToBeBuilt>,
 
     @Override
     public MethodSpec.Builder createMethod(final String generatedCodeName, final ClaimableOperation claimableOperation, final ParameterizedTypeName paramTn) {
-        return createMethod(generatedCodeName, claimableOperation.operationName() + "$#$" + paramTn.toString());
+        return createMethod(generatedCodeName, claimableOperation.operationName() + "$#$" + paramTn);
     }
 
     @Override

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/BeanScopeFactory.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/BeanScopeFactory.java
@@ -3,6 +3,7 @@ package io.github.cbarlin.aru.core.factories;
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.BeanScopeBuilder;
 import io.avaje.inject.spi.AvajeModule;
+import io.github.cbarlin.aru.annotations.Generated;
 import io.github.cbarlin.aru.core.APContext;
 import io.github.cbarlin.aru.core.CoreGlobalModule;
 import io.github.cbarlin.aru.core.CorePerComponentModule;
@@ -17,6 +18,7 @@ import io.github.cbarlin.aru.core.wiring.InjectModuleFinder;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.RecordComponentElement;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
@@ -30,13 +32,16 @@ public final class BeanScopeFactory {
         ServiceLoader.load(InjectModuleFinder.class, InjectModuleFinder.class.getClassLoader())
             .iterator()
             .forEachRemaining(finders::add);
+        finders.sort(Comparator.comparing(f -> f.getClass().getCanonicalName()));
         MODULE_FINDERS = List.copyOf(finders);
     }
 
+    @Generated("The constructor does not need to count for code coverage")
     private BeanScopeFactory() {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
 
+    @Generated("We do not use a daemon, so this will never count as tested")
     private static void ensureAPContextConfiguredCorrectly(final ProcessingEnvironment processingEnvironment) {
         final ProcessingEnvironment other;
         try {

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/BeanScopeFactory.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/BeanScopeFactory.java
@@ -3,6 +3,7 @@ package io.github.cbarlin.aru.core.factories;
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.BeanScopeBuilder;
 import io.avaje.inject.spi.AvajeModule;
+import io.github.cbarlin.aru.core.APContext;
 import io.github.cbarlin.aru.core.CoreGlobalModule;
 import io.github.cbarlin.aru.core.CorePerComponentModule;
 import io.github.cbarlin.aru.core.CorePerInterfaceModule;
@@ -36,8 +37,23 @@ public final class BeanScopeFactory {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
 
+    private static void ensureAPContextConfiguredCorrectly(final ProcessingEnvironment processingEnvironment) {
+        final ProcessingEnvironment other;
+        try {
+            other = APContext.processingEnv();
+        } catch (IllegalStateException e) {
+            APContext.init(processingEnvironment);
+            return;
+        }
+        if (other != processingEnvironment) {
+            APContext.clear();
+            APContext.init(processingEnvironment);
+        }
+    }
+
     public static BeanScope loadGlobalScope(final ProcessingEnvironment processingEnvironment) {
         NoOpHandler.install();
+        ensureAPContextConfiguredCorrectly(processingEnvironment);
         final PropertyConfigLoader propertyConfigLoader = new PropertyConfigLoader(Optional.empty());
         final BeanScopeBuilder coreScopeBuilder = BeanScope.builder();
         coreScopeBuilder.configPlugin(propertyConfigLoader);

--- a/docs/generated-code/options/builder-generation-validator.adoc
+++ b/docs/generated-code/options/builder-generation-validator.adoc
@@ -1,0 +1,67 @@
+****
+
+.Generated code when using `+JAKARTA_PLAIN+`
+[%collapsible]
+=====
+[source,java]
+----
+public final class PersonUtils implements GeneratedUtil {
+    public static final class Builder {
+        public Person build() {
+            // "Creating new instance"
+            return new Person(
+                    this.name()
+                    );
+        }
+
+        public Person build(@NonNull final Validator validator, @NonNull final Consumer<Set<ConstraintViolation<Person>>> resultConsumer) {
+            final Person built = this.build();
+            final Set<ConstraintViolation<Person>> validationResults = validator.validate(built);
+            if (Objects.nonNull(validationResults) && (!validationResults.isEmpty())) {
+                resultConsumer.accept(validationResults);
+            }
+            return built;
+        }
+
+        public Person build(@NonNull final Validator validator,
+                @NonNull final BiConsumer<Set<ConstraintViolation<Person>>, Person> resultConsumer) {
+            final Person built = this.build();
+            final Set<ConstraintViolation<Person>> validationResults = validator.validate(built);
+            resultConsumer.accept(validationResults, built);
+            return built;
+        }
+    }
+}
+----
+=====
+
+.Generated code when using `+AVAJE+`
+[%collapsible]
+=====
+[source,java]
+----
+public final class PersonUtils implements GeneratedUtil {
+    public static final class Builder {
+        public Person build() {
+            // "Creating new instance"
+            return new Person(
+                    this.name()
+                    );
+        }
+
+        public Person build(@NonNull final Validator validator, @Nullable final Class<?>... groups) throws ConstraintViolationException {
+            final Person built = this.build();
+            validator.validate(built, groups);
+            return built;
+        }
+
+        public Person buildAndValidate(@Nullable final Class<?>... groups) throws ConstraintViolationException {
+            return this.build(Validator.builder().build(), groups);
+        }
+    }
+}
+----
+=====
+
+
+****

--- a/docs/get-started.adoc
+++ b/docs/get-started.adoc
@@ -139,7 +139,7 @@ Assuming you have done everything else you need to do for reproducible builds (s
 
 NOTE: If your build isn't reproducible and it should be, please create a new issue on our GitHub.
 
-CAUTION: If you use MapStruct and want reproducible builds, you'll need to disable `+mapstruct.suppressGeneratorTimestamp+` and possibly also `+mapstruct.suppressGeneratorVersionInfoComment+`. See https://mapstruct.org/documentation/stable/reference/html/#configuration-options[their documentation^] for more details.
+CAUTION: If you use MapStruct and want reproducible builds, you'll need to set `+mapstruct.suppressGeneratorTimestamp=true+` and possibly also `+mapstruct.suppressGeneratorVersionInfoComment=true+`. See https://mapstruct.org/documentation/stable/reference/html/#configuration-options[their documentation^] for details on how to set those settings.
 
 == Generated code
 

--- a/docs/get-started.adoc
+++ b/docs/get-started.adoc
@@ -125,8 +125,9 @@ This library has optional integration with several dependencies. Some of these i
 
 Other integrations are based purely on detecting the dependency in your classpath and using them where it makes sense to do so without you being required to do anything. These integrations are:
 
-* Eclipse Collections
-* Apache commons-lang3
+* https://github.com/eclipse-collections/eclipse-collections[Eclipse Collections^] - Collections from Eclipse Collections are detected if referenced and handled appropriately (e.g. creating `+ImmutableList+` if requested).
+* https://commons.apache.org/proper/commons-lang/[Apache commons-lang3^] - Commons Lang 3, if detected, will be used for `+Validate+` and `+StringUtils+` classes
+* https://mapstruct.org/[MapStruct^] - Integration has been made on our end so that MapStruct will use our builders.
 
 == Reproducible Builds
 
@@ -137,6 +138,8 @@ This project is reproducible (and independently verified - thanks https://github
 Assuming you have done everything else you need to do for reproducible builds (see the https://reproducible-builds.org/docs/jvm/[JVM guide]) then use of Advanced Record Utils will not stop that (barring one edge case - see "Importing records/interfaces" below).
 
 NOTE: If your build isn't reproducible and it should be, please create a new issue on our GitHub.
+
+CAUTION: If you use MapStruct and want reproducible builds, you'll need to disable `+mapstruct.suppressGeneratorTimestamp+` and possibly also `+mapstruct.suppressGeneratorVersionInfoComment+`. See https://mapstruct.org/documentation/stable/reference/html/#configuration-options[their documentation^] for more details.
 
 == Generated code
 

--- a/docs/get-started.adoc
+++ b/docs/get-started.adoc
@@ -126,7 +126,7 @@ This library has optional integration with several dependencies. Some of these i
 Other integrations are based purely on detecting the dependency in your classpath and using them where it makes sense to do so without you being required to do anything. These integrations are:
 
 * https://github.com/eclipse-collections/eclipse-collections[Eclipse Collections^] - Collections from Eclipse Collections are detected if referenced and handled appropriately (e.g. creating `+ImmutableList+` if requested).
-* https://commons.apache.org/proper/commons-lang/[Apache commons-lang3^] - Commons Lang 3, if detected, will be used for `+Validate+` and `+StringUtils+` classes
+* https://commons.apache.org/proper/commons-lang/[Apache Commons Lang 3^] - Commons Lang 3, if detected, will be used for `+Validate+` and `+StringUtils+` classes
 * https://mapstruct.org/[MapStruct^] - Integration has been made on our end so that MapStruct will use our builders.
 
 == Reproducible Builds

--- a/docs/options/aru-builder/generation.adoc
+++ b/docs/options/aru-builder/generation.adoc
@@ -326,3 +326,108 @@ PersonUtils.builder()
 include::../../generated-code/options/builder-generation-optional.adoc[]
 
 ====
+
+[#options-builder-generation-validated]
+.`+validatedBuilder+`
+[%collapsible]
+====
+Should there be versions of the build methods that validate the built item?
+
+*Type*:: https://javadoc.io/doc/io.github.cbarlin/advanced-record-utils-annotations/latest/io.github.cbarlin.aru.annotations/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.ValidationApi.html[`+ValidationApi+`^]
+*Default*:: `+ValidationApi.NONE+`
+
+.Usage
+[source,java]
+----
+@AdvancedRecordUtils(
+    builderOptions = @BuilderOptions(
+        validatedBuilder = ValidationApi.AVAJE
+    )
+)
+public record Person(
+    @NonNull @NotBlank @Size(max = 50)
+    String name
+) {
+}
+----
+
+There are three possible values, with the default `+NONE+` not generating any additional methods.
+
+NOTE: Use of any value other than `+NONE+` will need the necessary dependencies.
+
+The value of `+JAKARTA_PLAIN+` generates methods that allow you to use Jakarta's validation API directly in order to validate the built object like so:
+
+.Sample method body
+[source,java]
+----
+Validator validator = obtainValidator(); // You will need a validator
+PersonUtils.builder()
+    .build(
+        validator,
+        (Set<Set<ConstraintViolation<Person>>> violations) -> {
+            // This method is only called if there's at least one violation
+        }
+    );
+// Alternatively, you can do:
+PersonUtils.builder()
+    .build(
+        validator,
+        (Set<Set<ConstraintViolation<Person>>> violations, Person personThatWasBuilt) -> {
+            // This method is always called
+        }
+    );
+----
+
+The value of `+AVAJE+` generates methods that allows you to use the https://avaje.io/validator/[Avaje Validator^]. You can use it like so:
+
+.Sample method body
+[source,java]
+----
+Validator validator = obtainValidator(); // You will need a validator
+PersonUtils.Builder builder = PersonUtils.builder();
+try {
+    // These use your validator:
+    builder.build(validator);
+    builder.build(validator, GroupA.class, GroupB.class);
+    // These use the default validator
+    builder.buildAndValidate();
+    builder.buildAndValidate(GroupA.class, GroupB.class);
+    // And you can still use the original builder:
+    builder.build();
+} catch (ConstraintViolationException e) {
+    // Do something with the violations
+}
+----
+
+include::../../generated-code/options/builder-generation-validator.adoc[]
+
+====
+
+.`+mapStructValidatesWithAvaje+`
+[%collapsible]
+====
+When using both the Avaje validator (see <<#options-builder-generation-validated,validation settings>>) and MapStruct, should we request that MapStruct calls the method that uses the default validator?
+
+*Type*:: `+boolean+`
+*Default*:: `+false+`
+
+.Usage
+[source,java]
+----
+@AdvancedRecordUtils(
+    builderOptions = @BuilderOptions(
+        validatedBuilder = ValidationApi.AVAJE,
+        mapStructValidatesWithAvaje = true
+    )
+)
+@Valid
+public record Person(
+    @NonNull @NotBlank @Size(max = 50)
+    String name
+) {
+}
+----
+
+When set to `+true+` and the "buildAndValidate" method has been created then the MapStruct integration will call that method. If false, or if there's no "buildAndValidate" method, then it will use the default "build" method.
+
+====

--- a/pom.xml
+++ b/pom.xml
@@ -219,11 +219,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.tinylog</groupId>
-                <artifactId>slf4j-tinylog</artifactId>
-                <version>${tinylog.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.mapstruct</groupId>
                 <artifactId>mapstruct</artifactId>
                 <version>${mapstruct.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,13 +70,13 @@
         <jakarta-xml-bind-api.version>4.0.2</jakarta-xml-bind-api.version>
         <jspecify.version>1.0.0</jspecify.version>
         <junit-bom.version>5.13.4</junit-bom.version>
+        <mapstruct.version>1.6.3</mapstruct.version>
         <mockito.version>5.19.0</mockito.version>
         <stax2-api.version>4.2.2</stax2-api.version>
         <vavr.version>0.10.7</vavr.version>
         <woodstox.version>7.1.1</woodstox.version>
         <xmlunit.version>2.10.3</xmlunit.version>
         <rainbowgum.version>0.8.2</rainbowgum.version>
-        <tinylog.version>2.7.0</tinylog.version>
 
         <!-- Maven versions -->
         <central-publishing.version>0.8.0</central-publishing.version>
@@ -224,9 +224,14 @@
                 <version>${tinylog.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.tinylog</groupId>
-                <artifactId>tinylog-impl</artifactId>
-                <version>${tinylog.version}</version>
+                <groupId>org.mapstruct</groupId>
+                <artifactId>mapstruct</artifactId>
+                <version>${mapstruct.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mapstruct</groupId>
+                <artifactId>mapstruct-processor</artifactId>
+                <version>${mapstruct.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.jstach.rainbowgum</groupId>

--- a/utils-tests/d_eclipse_collections/pom.xml
+++ b/utils-tests/d_eclipse_collections/pom.xml
@@ -36,31 +36,44 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+        </dependency>
     </dependencies>
 
-<!--    <build>-->
-<!--        <plugins>-->
-<!--            <plugin>-->
-<!--                <artifactId>maven-compiler-plugin</artifactId>-->
-<!--                <configuration>-->
-<!--                    <annotationProcessorPaths>-->
-<!--                        <path>-->
-<!--                            <groupId>io.github.cbarlin</groupId>-->
-<!--                            <artifactId>advanced-record-utils-processor</artifactId>-->
-<!--                            <version>${project.version}</version>-->
-<!--                        </path>-->
-<!--                        <path>-->
-<!--                            <groupId>io.avaje</groupId>-->
-<!--                            <artifactId>avaje-jsonb-generator</artifactId>-->
-<!--                            <version>${avaje-jsonb.version}</version>-->
-<!--                        </path>-->
-<!--                    </annotationProcessorPaths>-->
-<!--                    <fork>true</fork>-->
-<!--                    <compilerArgs>-->
-<!--                        <arg>-J-agentpath:/home/conrad/bin/async-profiler-4.1-linux-x64/lib/libasyncProfiler.so=start,interval=100000,inverted,file=${project.basedir}/target/profile.html</arg>-->
-<!--                    </compilerArgs>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
-<!--        </plugins>-->
-<!--    </build>-->
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.avaje</groupId>
+                            <artifactId>avaje-jsonb-generator</artifactId>
+                            <version>${avaje-jsonb.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.github.cbarlin</groupId>
+                            <artifactId>advanced-record-utils-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <fork>true</fork>
+                    <compilerArgs>
+                        <arg>-J${jacoco.agent.argLine}</arg>
+                        <arg>-Amapstruct.suppressGeneratorTimestamp=true</arg>
+                        <arg>-Amapstruct.suppressGeneratorVersionInfoComment=true</arg>
+                        <!--                        <arg>-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005</arg>-->
+                        <!--                        <arg>-J-agentpath:/home/conrad/bin/async-profiler-4.1-linux-x64/lib/libasyncProfiler.so=start,file=${project.basedir}/target/profile.html</arg>-->
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/utils-tests/d_eclipse_collections/pom.xml
+++ b/utils-tests/d_eclipse_collections/pom.xml
@@ -40,6 +40,14 @@
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.avaje</groupId>
+            <artifactId>avaje-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.avaje</groupId>
+            <artifactId>avaje-validator-constraints</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -57,6 +65,11 @@
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
                             <version>${mapstruct.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.avaje</groupId>
+                            <artifactId>avaje-validator-generator</artifactId>
+                            <version>${avaje-validator.version}</version>
                         </path>
                         <path>
                             <groupId>io.github.cbarlin</groupId>

--- a/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/SomeImplA.java
+++ b/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/SomeImplA.java
@@ -1,13 +1,23 @@
 package io.github.cbarlin.aru.tests.d_eclipse_collections;
 
+import io.avaje.validation.constraints.NotBlank;
+import io.avaje.validation.constraints.Valid;
 import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
 import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.NameGeneration;
 import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.XmlOptions;
+import org.jspecify.annotations.NonNull;
 
 @AdvancedRecordUtils(
     xmlOptions = @XmlOptions(inferXmlElementName = NameGeneration.UPPER_FIRST_LETTER),
-    xmlable = true
+    xmlable = true,
+    builderOptions = @AdvancedRecordUtils.BuilderOptions(
+        validatedBuilder = AdvancedRecordUtils.ValidationApi.AVAJE
+    )
 )
-public record SomeImplA(String field) implements SomeIface {
+@Valid
+public record SomeImplA(
+    @NotBlank @NonNull
+    String field
+) implements SomeIface {
 
 }

--- a/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/SomeImplB.java
+++ b/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/SomeImplB.java
@@ -8,6 +8,9 @@ import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.XmlOptions;
     xmlOptions = @XmlOptions(inferXmlElementName = NameGeneration.UPPER_FIRST_LETTER),
     xmlable = true
 )
-public record SomeImplB(String field) implements SomeIface {
+public record SomeImplB(String anotherField, int iAmNotNeeded) implements SomeIface {
 
+    public SomeImplB(String anotherField) {
+        this(anotherField, 42);
+    }
 }

--- a/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/SomeImplB.java
+++ b/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/SomeImplB.java
@@ -6,7 +6,11 @@ import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.XmlOptions;
 
 @AdvancedRecordUtils(
     xmlOptions = @XmlOptions(inferXmlElementName = NameGeneration.UPPER_FIRST_LETTER),
-    xmlable = true
+    xmlable = true,
+    builderOptions = @AdvancedRecordUtils.BuilderOptions(
+        // We aren't enabling Avaje validation here, so this should just use the normal builder
+        mapStructValidatesWithAvaje = true
+    )
 )
 public record SomeImplB(String anotherField, int iAmNotNeeded) implements SomeIface {
 

--- a/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/SomeImplMapper.java
+++ b/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/SomeImplMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.factory.Mappers;
 @Mapper
 public interface SomeImplMapper {
 
-    SomeImplMapper INSTANCE = Mappers.getMapper( SomeImplMapper.class );
+    SomeImplMapper INSTANCE = Mappers.getMapper(SomeImplMapper.class);
 
     @Mapping(source = "field", target = "anotherField")
     SomeImplB fromA(final SomeImplA someImplA);

--- a/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/SomeImplMapper.java
+++ b/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/SomeImplMapper.java
@@ -1,0 +1,15 @@
+package io.github.cbarlin.aru.tests.d_eclipse_collections;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface SomeImplMapper {
+
+    SomeImplMapper INSTANCE = Mappers.getMapper( SomeImplMapper.class );
+
+    @Mapping(source = "field", target = "anotherField")
+    SomeImplB fromA(final SomeImplA someImplA);
+
+}

--- a/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/BasicAvajeValidatorTest.java
+++ b/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/BasicAvajeValidatorTest.java
@@ -1,0 +1,91 @@
+package io.github.cbarlin.aru.tests.d_eclipse_collections;
+
+import io.avaje.validation.ConstraintViolationException;
+import io.avaje.validation.Validator;
+import io.avaje.validation.groups.Default;
+import jakarta.xml.bind.ValidationException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BasicAvajeValidatorTest {
+
+    @Test
+    void validBuild() {
+        final String expected = "This has a value";
+        final SomeImplAUtils.Builder builder = SomeImplAUtils.builder()
+            .field(expected);
+
+        final SomeImplA a = assertDoesNotThrow(() -> builder.build(), "Original build should pass");
+        assertEquals(expected, a.field());
+        final SomeImplA b = assertDoesNotThrow(() -> builder.buildAndValidate(), "Build and validate should allow the item to be built");
+        assertEquals(expected, b.field());
+        final Validator validator = Validator.builder()
+            .setDefaultLocale(Locale.ENGLISH)
+            .build();
+        final SomeImplA c = assertDoesNotThrow(() -> builder.build(validator), "Build with a validator should pass");
+        assertEquals(expected, c.field());
+        final SomeImplA d = assertDoesNotThrow(() -> builder.build(validator, SomeImplA.class), "Build with a validator should pass");
+        assertEquals(expected, d.field());
+        final SomeImplA e = assertDoesNotThrow(() -> builder.buildAndValidate(SomeImplA.class), "Build with a validator should pass");
+        assertEquals(expected, e.field());
+    }
+
+    @Test
+    void unsetField() {
+        final SomeImplAUtils.Builder builder = SomeImplAUtils.builder();
+
+        final SomeImplA a = assertDoesNotThrow(() -> builder.build(), "Original build should pass");
+        assertNull(a.field());
+
+        final String message = "A null field should not be valid";
+        assertThrows(ConstraintViolationException.class, builder::buildAndValidate, message);
+        assertThrows(ConstraintViolationException.class, () -> builder.buildAndValidate(Default.class), message);
+        final Validator validator = Validator.builder()
+            .setDefaultLocale(Locale.ENGLISH)
+            .build();
+        assertThrows(ConstraintViolationException.class, () -> builder.build(validator), message);
+        assertThrows(ConstraintViolationException.class, () -> builder.build(validator, Default.class), message);
+    }
+
+    @Test
+    void emptyString() {
+        final SomeImplAUtils.Builder builder = SomeImplAUtils.builder()
+            .field("");
+
+        final SomeImplA a = assertDoesNotThrow(() -> builder.build(), "Original build should pass");
+        assertEquals("", a.field());
+
+        final String message = "An empty string should not be valid";
+        assertThrows(ConstraintViolationException.class, builder::buildAndValidate, message);
+        assertThrows(ConstraintViolationException.class, () -> builder.buildAndValidate(Default.class), message);
+        final Validator validator = Validator.builder()
+            .setDefaultLocale(Locale.ENGLISH)
+            .build();
+        assertThrows(ConstraintViolationException.class, () -> builder.build(validator), message);
+        assertThrows(ConstraintViolationException.class, () -> builder.build(validator, Default.class), message);
+    }
+
+    @Test
+    void blankString() {
+        final SomeImplAUtils.Builder builder = SomeImplAUtils.builder()
+            .field("              ");
+
+        final SomeImplA a = assertDoesNotThrow(() -> builder.build(), "Original build should pass");
+        assertEquals("              ", a.field());
+
+        final String message = "An blank string should not be valid";
+        assertThrows(ConstraintViolationException.class, builder::buildAndValidate, message);
+        assertThrows(ConstraintViolationException.class, () -> builder.buildAndValidate(Default.class), message);
+        final Validator validator = Validator.builder()
+            .setDefaultLocale(Locale.ENGLISH)
+            .build();
+        assertThrows(ConstraintViolationException.class, () -> builder.build(validator), message);
+        assertThrows(ConstraintViolationException.class, () -> builder.build(validator, Default.class), message);
+    }
+}

--- a/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/BasicMapStructTest.java
+++ b/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/BasicMapStructTest.java
@@ -13,6 +13,8 @@ class BasicMapStructTest {
             .build();
         final SomeImplB b = SomeImplMapper.INSTANCE.fromA(a);
         assertEquals(a.field(), b.anotherField());
+        // This proves that MapStruct has used the builder, as otherwise it'll
+        //   pass '0' to the canonical constructor
         assertEquals(42, b.iAmNotNeeded());
     }
 }

--- a/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/BasicMapStructTest.java
+++ b/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/BasicMapStructTest.java
@@ -1,0 +1,18 @@
+package io.github.cbarlin.aru.tests.d_eclipse_collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BasicMapStructTest {
+
+    @Test
+    void canSwap() {
+        final SomeImplA a = SomeImplAUtils.builder()
+            .field("This is a value")
+            .build();
+        final SomeImplB b = SomeImplMapper.INSTANCE.fromA(a);
+        assertEquals(a.field(), b.anotherField());
+        assertEquals(42, b.iAmNotNeeded());
+    }
+}

--- a/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/BasicMapStructTest.java
+++ b/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/BasicMapStructTest.java
@@ -15,6 +15,6 @@ class BasicMapStructTest {
         assertEquals(a.field(), b.anotherField());
         // This proves that MapStruct has used the builder, as otherwise it'll
         //   pass '0' to the canonical constructor
-        assertEquals(42, b.iAmNotNeeded());
+        assertEquals(42, b.iAmNotNeeded(), "ARU Builder was not used");
     }
 }


### PR DESCRIPTION
Fixes #94, Fixes #113, Fixes #112.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added MapStruct integration to enable ARU-style builder use during mappings.

- Documentation
  - Updated Get Started with MapStruct setup, reproducible-build flags and centralised version guidance for Maven/Gradle.

- Chores
  - Introduced central MapStruct version and managed dependencies; declared MapStruct as optional/provided where appropriate and enabled processor configuration in tests.

- Refactor
  - Revised processor lifecycle and shared processing context handling for more robust multi-tool integration.

- Tests
  - Added mapper and unit test demonstrating mapping with defaulted fields; enabled deterministic MapStruct processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->