### PR TITLE
Fix merging Eclipse Collections

### DIFF
--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/eclipse/list/EclipseImmutableList.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/eclipse/list/EclipseImmutableList.java
@@ -3,7 +3,15 @@ package io.github.cbarlin.aru.impl.types.collection.eclipse.list;
 import io.avaje.inject.Component;
 import io.avaje.inject.RequiresProperty;
 import io.github.cbarlin.aru.impl.wiring.GlobalScope;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
 
+import javax.lang.model.element.Modifier;
+
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
 import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames.ECLIPSE_COLLECTIONS__IMMUTABLE_LIST;
 import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames.ECLIPSE_COLLECTIONS__PROPERTY;
 
@@ -16,4 +24,28 @@ public final class EclipseImmutableList extends EclipseListCollectionHandler {
         super(ECLIPSE_COLLECTIONS__IMMUTABLE_LIST);
     }
 
+    @Override
+    public void writeMergerMethod(TypeName innerType, MethodSpec.Builder methodBuilder) {
+        final ParameterizedTypeName paramTypeName = ParameterizedTypeName.get(classNameOnComponent, innerType);
+        final ParameterSpec paramA = ParameterSpec.builder(paramTypeName, "elA", Modifier.FINAL)
+            .addAnnotation(NULLABLE)
+            .addJavadoc("The preferred input")
+            .build();
+
+        final ParameterSpec paramB = ParameterSpec.builder(paramTypeName, "elB", Modifier.FINAL)
+            .addAnnotation(NULLABLE)
+            .addJavadoc("The non-preferred input")
+            .build();
+        methodBuilder.addAnnotation(NULLABLE)
+            .addParameter(paramA)
+            .addParameter(paramB)
+            .returns(paramTypeName)
+            .addJavadoc("Merger for fields of class {@link $T}", paramTypeName)
+            .beginControlFlow("if ($T.isNull(elA) || elA.isEmpty())", OBJECTS)
+            .addStatement("return elB")
+            .nextControlFlow("else if ($T.isNull(elB) || elB.isEmpty())", OBJECTS)
+            .addStatement("return elA")
+            .endControlFlow()
+            .addStatement("return elA.newWithAll(elB)");
+    }
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/eclipse/set/EclipseImmutableSet.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/eclipse/set/EclipseImmutableSet.java
@@ -3,7 +3,15 @@ package io.github.cbarlin.aru.impl.types.collection.eclipse.set;
 import io.avaje.inject.Component;
 import io.avaje.inject.RequiresProperty;
 import io.github.cbarlin.aru.impl.wiring.GlobalScope;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
 
+import javax.lang.model.element.Modifier;
+
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
 import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames.ECLIPSE_COLLECTIONS__IMMUTABLE_SET;
 import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames.ECLIPSE_COLLECTIONS__PROPERTY;
 
@@ -14,5 +22,30 @@ public final class EclipseImmutableSet extends EclipseSetCollectionHandler {
 
     public EclipseImmutableSet() {
         super(ECLIPSE_COLLECTIONS__IMMUTABLE_SET);
+    }
+
+    @Override
+    public void writeMergerMethod(TypeName innerType, MethodSpec.Builder methodBuilder) {
+        final ParameterizedTypeName paramTypeName = ParameterizedTypeName.get(classNameOnComponent, innerType);
+        final ParameterSpec paramA = ParameterSpec.builder(paramTypeName, "elA", Modifier.FINAL)
+            .addAnnotation(NULLABLE)
+            .addJavadoc("The preferred input")
+            .build();
+
+        final ParameterSpec paramB = ParameterSpec.builder(paramTypeName, "elB", Modifier.FINAL)
+            .addAnnotation(NULLABLE)
+            .addJavadoc("The non-preferred input")
+            .build();
+        methodBuilder.addAnnotation(NULLABLE)
+            .addParameter(paramA)
+            .addParameter(paramB)
+            .returns(paramTypeName)
+            .addJavadoc("Merger for fields of class {@link $T}", paramTypeName)
+            .beginControlFlow("if ($T.isNull(elA) || elA.isEmpty())", OBJECTS)
+            .addStatement("return elB")
+            .nextControlFlow("else if ($T.isNull(elB) || elB.isEmpty())", OBJECTS)
+            .addStatement("return elA")
+            .endControlFlow()
+            .addStatement("return elA.newWithAll(elB)");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <project.build.outputTimestamp>2025-08-29T08:12:26Z</project.build.outputTimestamp>
 
         <!-- Dependencies -->
-        <avaje-jsonb.version>3.6</avaje-jsonb.version>
+        <avaje-jsonb.version>3.7</avaje-jsonb.version>
         <avaje-prism.version>1.43</avaje-prism.version>
         <avaje-spi.version>2.13</avaje-spi.version>
         <avaje-validator.version>2.13</avaje-validator.version>
@@ -64,7 +64,7 @@
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <eclipse-collections.version>13.0.0</eclipse-collections.version>
         <guava.version>33.4.8-jre</guava.version>
-        <jackson-annotations.version>2.19.2</jackson-annotations.version>
+        <jackson-annotations.version>2.20.0</jackson-annotations.version>
         <jacoco.version>0.8.13</jacoco.version>
         <jakarta-validation.version>3.1.1</jakarta-validation.version>
         <jakarta-xml-bind-api.version>4.0.2</jakarta-xml-bind-api.version>

--- a/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/DependsOnRecord.java
+++ b/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/DependsOnRecord.java
@@ -6,7 +6,10 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.ImmutableSet;
 
-@AdvancedRecordUtils(attemptToFindExistingUtils = true)
+@AdvancedRecordUtils(
+    attemptToFindExistingUtils = true,
+    merger = true
+)
 public record DependsOnRecord(
     ImmutableList<MyRecordA> immutableListOfA,
     MutableList<MyRecordA> mutableListOfA,


### PR DESCRIPTION
Previous versions (not sure how many) would create code that could not compile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added null-safe merge support for Eclipse Collections-based fields, including immutable List and Set variants. When both inputs are present, elements are combined; empty or null inputs are gracefully handled.
- Tests
  - Enabled merger scenarios in test records to validate collection-merge behaviour.
- Chores
  - Updated dependencies: avaje-jsonb to 3.7 and Jackson Annotations to 2.20.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->