### PR TITLE
Add optional remove/retain methods

### DIFF
--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
@@ -11,6 +11,7 @@ public enum Constants {
     ;
     public enum Claims {
         ;
+        // Please keep in alphabetical order
         public static final ClaimableOperation ALL_IFACE = new ClaimableOperation("allIface", CLASS);
         public static final ClaimableOperation BUILDER_ADD_ALL_ITERABLE = new ClaimableOperation("builderAddAllIterable", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_ADD_ALL_VARARGS = new ClaimableOperation("builderAddAllVarargs", FIELD_AND_ACCESSORS);
@@ -18,6 +19,10 @@ public enum Constants {
         public static final ClaimableOperation BUILDER_ALIAS_SETTER = new ClaimableOperation("builderAliasSetter", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_CONCRETE_OPTIONAL = new ClaimableOperation("builderConcreteSetterForOptional", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_FLUENT_SETTER = new ClaimableOperation("builderFluentSetter", FIELD_AND_ACCESSORS);
+        public static final ClaimableOperation BUILDER_REMOVE_ALL_ITERABLE = new ClaimableOperation("builderRemoveAllIterable", FIELD_AND_ACCESSORS);
+        public static final ClaimableOperation BUILDER_REMOVE_IF = new ClaimableOperation("builderRemoveIf", FIELD_AND_ACCESSORS);
+        public static final ClaimableOperation BUILDER_REMOVE_SINGLE = new ClaimableOperation("builderRemoveSingle", FIELD_AND_ACCESSORS);
+        public static final ClaimableOperation BUILDER_RETAIN_ALL = new ClaimableOperation("builderRetainAll", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_SET_TIME_TO_NOW = new ClaimableOperation("builderSetTimeToNow", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_SET_TO_NULL = new ClaimableOperation("builderSetToNull", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_USE_TYPE_CONVERTER = new ClaimableOperation("builderUseTypeConverter", FIELD_AND_ACCESSORS);
@@ -31,12 +36,12 @@ public enum Constants {
         public static final ClaimableOperation DIFFER_UTILS_COMPUTE_CHANGE = new ClaimableOperation("differUtilsComputation", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation DIFFER_VALUE_HOLDING = new ClaimableOperation("differValueHolding", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation INTERNAL_MATCHING_IFACE = new ClaimableOperation("internalMatchingIface", FIELD_AND_ACCESSORS);
-        public static final ClaimableOperation MERGE_IFACE_MERGE = new ClaimableOperation("mergeInterfaceMergeMethod", CLASS);
-        public static final ClaimableOperation MERGE_IFACE_MERGE_OPTIONAL = new ClaimableOperation("mergeInterfaceMergeOptionalMethod", CLASS);
-        public static final ClaimableOperation MERGE_STATIC_MERGE = new ClaimableOperation("mergeStaticMergeMethod", CLASS);
         public static final ClaimableOperation MERGER_ADD_FIELD_MERGER_METHOD = new ClaimableOperation("mergerAddFieldMergerMethod", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation MERGER_IFACE = new ClaimableOperation("mergerInterface", CLASS);
         public static final ClaimableOperation MERGER_STATIC_CLASS = new ClaimableOperation("mergerStaticClass", CLASS);
+        public static final ClaimableOperation MERGE_IFACE_MERGE = new ClaimableOperation("mergeInterfaceMergeMethod", CLASS);
+        public static final ClaimableOperation MERGE_IFACE_MERGE_OPTIONAL = new ClaimableOperation("mergeInterfaceMergeOptionalMethod", CLASS);
+        public static final ClaimableOperation MERGE_STATIC_MERGE = new ClaimableOperation("mergeStaticMergeMethod", CLASS);
         public static final ClaimableOperation MISC_AVAJE_JSONB_IMPORT = new ClaimableOperation("miscAvajeJsonbImport", CLASS);
         public static final ClaimableOperation WITHER_FLUENT_BUILDER = new ClaimableOperation("witherFluentBuilder", CLASS);
         public static final ClaimableOperation WITHER_IFACE = new ClaimableOperation("wither", CLASS);
@@ -47,11 +52,13 @@ public enum Constants {
         public static final ClaimableOperation WITHER_WITH_ALIAS = new ClaimableOperation("witherWithAlias", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation WITHER_WITH_FLUENT = new ClaimableOperation("witherWithFluent", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation WITHER_WITH_OPTIONAL = new ClaimableOperation("witherWithOptional", FIELD_AND_ACCESSORS);
+        public static final ClaimableOperation WITHER_WITH_REMOVE = new ClaimableOperation("witherWithRemove", FIELD_AND_ACCESSORS);
+        public static final ClaimableOperation WITHER_WITH_RETAIN = new ClaimableOperation("witherWithRetain", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation XML_IFACE = new ClaimableOperation("xmlInterface", CLASS);
         public static final ClaimableOperation XML_IFACE_TO_XML = new ClaimableOperation("xmlInterfaceToXml", CLASS);
+        public static final ClaimableOperation XML_IFACE_TO_XML_NOT_TAG = new ClaimableOperation("xmlInterfaceToXmlNoTag", CLASS);
         public static final ClaimableOperation XML_IFACE_TO_XML_NO_DEF_NAMESPACE = new ClaimableOperation("xmlInterfaceToXmlNoDefNs", CLASS);
         public static final ClaimableOperation XML_IFACE_TO_XML_NO_NAMESPACE = new ClaimableOperation("xmlInterfaceToXmlNoNs", CLASS);
-        public static final ClaimableOperation XML_IFACE_TO_XML_NOT_TAG = new ClaimableOperation("xmlInterfaceToXmlNoTag", CLASS);
         public static final ClaimableOperation XML_STATIC_CLASS = new ClaimableOperation("xmlStaticClass", CLASS);
         public static final ClaimableOperation XML_STATIC_CLASS_TO_XML = new ClaimableOperation("xmlStaticClassToXml", CLASS);
         public static final ClaimableOperation XML_STATIC_CLASS_TO_XML_NO_DEF_NAMESPACE = new ClaimableOperation("xmlStaticClassToXmlNoDefNS", CLASS);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddRemoveAll.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddRemoveAll.java
@@ -1,0 +1,44 @@
+package io.github.cbarlin.aru.impl.builder.collection;
+
+import io.avaje.inject.Component;
+import io.avaje.inject.RequiresBean;
+import io.avaje.inject.RequiresProperty;
+import io.github.cbarlin.aru.core.artifacts.BuilderClass;
+import io.github.cbarlin.aru.core.types.components.AnalysedCollectionComponent;
+import io.github.cbarlin.aru.core.types.components.ConstructorComponent;
+import io.github.cbarlin.aru.core.visitors.CollectionRecordVisitor;
+import io.github.cbarlin.aru.impl.Constants.Claims;
+import io.github.cbarlin.aru.impl.types.collection.CollectionHandlerHelper;
+import io.github.cbarlin.aru.impl.wiring.BuilderPerComponentScope;
+
+@Component
+@BuilderPerComponentScope
+@RequiresProperty(value = "createRemoveMethods", equalTo = "true")
+@RequiresBean({CollectionHandlerHelper.class, ConstructorComponent.class, AnalysedCollectionComponent.class})
+public final class AddRemoveAll extends CollectionRecordVisitor {
+
+    private final CollectionHandlerHelper minimalCollectionHandler;
+    private final BuilderClass builderClass;
+
+    public AddRemoveAll(
+        final AnalysedCollectionComponent acc,
+        final BuilderClass builderClass,
+        final CollectionHandlerHelper minimalCollectionHandler
+    ) {
+        super(Claims.BUILDER_REMOVE_ALL_ITERABLE, acc.parentRecord(), acc);
+        this.minimalCollectionHandler = minimalCollectionHandler;
+        this.builderClass = builderClass;
+    }
+
+    @Override
+    protected int collectionSpecificity() {
+        return 1;
+    }
+
+    @Override
+    protected boolean visitCollectionComponent() {
+        final String addName = removeNameMethodName();
+        minimalCollectionHandler.writeRemoveMany(builderClass, addName, addName, this);
+        return true;
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddRemovePredicate.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddRemovePredicate.java
@@ -1,0 +1,75 @@
+package io.github.cbarlin.aru.impl.builder.collection;
+
+import io.avaje.inject.Component;
+import io.avaje.inject.RequiresBean;
+import io.avaje.inject.RequiresProperty;
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.artifacts.BuilderClass;
+import io.github.cbarlin.aru.core.types.components.AnalysedCollectionComponent;
+import io.github.cbarlin.aru.core.types.components.ConstructorComponent;
+import io.github.cbarlin.aru.core.visitors.CollectionRecordVisitor;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.types.collection.CollectionHandlerHelper;
+import io.github.cbarlin.aru.impl.wiring.BuilderPerComponentScope;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+import javax.lang.model.element.Modifier;
+
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.NON_NULL;
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
+
+@Component
+@BuilderPerComponentScope
+@RequiresProperty(value = "createRemoveMethods", equalTo = "true")
+@RequiresBean({CollectionHandlerHelper.class, ConstructorComponent.class, AnalysedCollectionComponent.class})
+public final class AddRemovePredicate extends CollectionRecordVisitor {
+
+    private final CollectionHandlerHelper minimalCollectionHandler;
+    private final BuilderClass builderClass;
+
+    public AddRemovePredicate(
+        final AnalysedCollectionComponent acc,
+        final BuilderClass builderClass,
+        final CollectionHandlerHelper minimalCollectionHandler
+    ) {
+        super(Constants.Claims.BUILDER_REMOVE_IF, acc.parentRecord(), acc);
+        this.minimalCollectionHandler = minimalCollectionHandler;
+        this.builderClass = builderClass;
+    }
+
+    @Override
+    public int collectionSpecificity() {
+        return 5;
+    }
+
+    @Override
+    protected boolean visitCollectionComponent() {
+        final String methodName = removeNameMethodName();
+        final MethodSpec.Builder method = builderClass.createMethod(methodName, claimableOperation, analysedCollectionComponent.element());
+        final String name = analysedCollectionComponent.name();
+        final TypeName innerType = analysedCollectionComponent.unNestedPrimaryTypeName();
+        final ParameterizedTypeName ptn = ParameterizedTypeName.get(Constants.Names.PREDICATE, innerType);
+
+        final ParameterSpec param = ParameterSpec.builder(ptn, name, Modifier.FINAL)
+            .addJavadoc("A predicate to use to evaluate if an item should be removed from a collection")
+            .addAnnotation(NON_NULL)
+            .build();
+
+        method.addJavadoc("Remove {@link $T} items from the {@code $L} collection based on the provided predicate", innerType, name)
+            .returns(builderClass.className())
+            .addParameter(param)
+            .addAnnotation(NON_NULL)
+            .addModifiers(Modifier.PUBLIC)
+            .addStatement("$T.requireNonNull($L, $S)", OBJECTS, name, "Cannot provide a null predicate");
+
+        minimalCollectionHandler.writeRemovePredicate(method);
+
+        method.addStatement("return this");
+        AnnotationSupplier.addGeneratedAnnotation(method, this);
+
+        return true;
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddRemover.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddRemover.java
@@ -1,0 +1,72 @@
+package io.github.cbarlin.aru.impl.builder.collection;
+
+import io.avaje.inject.Component;
+import io.avaje.inject.RequiresBean;
+import io.avaje.inject.RequiresProperty;
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.artifacts.BuilderClass;
+import io.github.cbarlin.aru.core.types.components.AnalysedCollectionComponent;
+import io.github.cbarlin.aru.core.types.components.ConstructorComponent;
+import io.github.cbarlin.aru.core.visitors.CollectionRecordVisitor;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.types.collection.CollectionHandlerHelper;
+import io.github.cbarlin.aru.impl.wiring.BuilderPerComponentScope;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+import javax.lang.model.element.Modifier;
+
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.NON_NULL;
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
+
+@Component
+@BuilderPerComponentScope
+@RequiresProperty(value = "createRemoveMethods", equalTo = "true")
+@RequiresBean({CollectionHandlerHelper.class, ConstructorComponent.class, AnalysedCollectionComponent.class})
+public final class AddRemover extends CollectionRecordVisitor {
+
+    private final CollectionHandlerHelper minimalCollectionHandler;
+    private final BuilderClass builderClass;
+
+    public AddRemover(
+        final AnalysedCollectionComponent acc,
+        final BuilderClass builderClass,
+        final CollectionHandlerHelper minimalCollectionHandler
+    ) {
+        super(Constants.Claims.BUILDER_REMOVE_SINGLE, acc.parentRecord(), acc);
+        this.minimalCollectionHandler = minimalCollectionHandler;
+        this.builderClass = builderClass;
+    }
+
+    @Override
+    public int collectionSpecificity() {
+        return 5;
+    }
+
+    @Override
+    protected boolean visitCollectionComponent() {
+        final String methodName = removeNameMethodName();
+        final MethodSpec.Builder method = builderClass.createMethod(methodName, claimableOperation, analysedCollectionComponent.element());
+        final String name = analysedCollectionComponent.name();
+        final TypeName innerType = analysedCollectionComponent.unNestedPrimaryTypeName();
+
+        final ParameterSpec param = ParameterSpec.builder(innerType, name, Modifier.FINAL)
+            .addJavadoc("A singular instance to be removed from the collection")
+            .addAnnotation(NULLABLE)
+            .build();
+
+        method.addJavadoc("Remove a singular {@link $T} to the collection for the field {@code $L}", innerType, name)
+            .returns(builderClass.className())
+            .addParameter(param)
+            .addAnnotation(NON_NULL)
+            .addModifiers(Modifier.PUBLIC);
+
+        minimalCollectionHandler.writeRemoveSingle(method);
+
+        method.addStatement("return this");
+        AnnotationSupplier.addGeneratedAnnotation(method, this);
+
+        return true;
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddRetainAll.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/collection/AddRetainAll.java
@@ -1,0 +1,78 @@
+package io.github.cbarlin.aru.impl.builder.collection;
+
+import io.avaje.inject.Component;
+import io.avaje.inject.RequiresBean;
+import io.avaje.inject.RequiresProperty;
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.CommonsConstants;
+import io.github.cbarlin.aru.core.artifacts.BuilderClass;
+import io.github.cbarlin.aru.core.types.components.AnalysedCollectionComponent;
+import io.github.cbarlin.aru.core.types.components.ConstructorComponent;
+import io.github.cbarlin.aru.core.visitors.CollectionRecordVisitor;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.types.collection.CollectionHandlerHelper;
+import io.github.cbarlin.aru.impl.wiring.BuilderPerComponentScope;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+import javax.lang.model.element.Modifier;
+
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.NON_NULL;
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
+
+@Component
+@BuilderPerComponentScope
+@RequiresProperty(value = "createRetainAllMethod", equalTo = "true")
+@RequiresBean({CollectionHandlerHelper.class, ConstructorComponent.class, AnalysedCollectionComponent.class})
+public final class AddRetainAll extends CollectionRecordVisitor {
+
+    private final CollectionHandlerHelper minimalCollectionHandler;
+    private final BuilderClass builderClass;
+
+    public AddRetainAll(
+        final AnalysedCollectionComponent acc,
+        final BuilderClass builderClass,
+        final CollectionHandlerHelper minimalCollectionHandler
+    ) {
+        super(Constants.Claims.BUILDER_RETAIN_ALL, acc.parentRecord(), acc);
+        this.minimalCollectionHandler = minimalCollectionHandler;
+        this.builderClass = builderClass;
+    }
+
+    @Override
+    public int collectionSpecificity() {
+        return 5;
+    }
+
+    @Override
+    protected boolean visitCollectionComponent() {
+        final String methodName = analysedCollectionComponent.settings().prism().builderOptions().retainMethodPrefix() +
+            capitalise(analysedCollectionComponent.name()) +
+            analysedCollectionComponent.settings().prism().builderOptions().retainMethodSuffix();
+        final MethodSpec.Builder method = builderClass.createMethod(methodName, claimableOperation, analysedCollectionComponent.element());
+        final String name = analysedCollectionComponent.name();
+        final TypeName innerType = analysedCollectionComponent.unNestedPrimaryTypeName();
+        final ParameterizedTypeName ptn = ParameterizedTypeName.get(CommonsConstants.Names.COLLECTION, innerType);
+
+        final ParameterSpec param = ParameterSpec.builder(ptn, name, Modifier.FINAL)
+            .addJavadoc("The collection of items to be retained in the collection")
+            .addAnnotation(NON_NULL)
+            .build();
+
+        method.addJavadoc("Retain only {@link $T} items from the {@code $L} collection if they are present in the provided collection", innerType, name)
+            .returns(builderClass.className())
+            .addParameter(param)
+            .addAnnotation(NON_NULL)
+            .addModifiers(Modifier.PUBLIC)
+            .addStatement("$T.requireNonNull($L, $S)", OBJECTS, name, "Cannot provide a null collection");
+
+        minimalCollectionHandler.writeRetainAll(method);
+
+        method.addStatement("return this");
+        AnnotationSupplier.addGeneratedAnnotation(method, this);
+
+        return true;
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/CollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/CollectionHandler.java
@@ -79,8 +79,43 @@ public abstract class CollectionHandler {
         final String addAllMethodName,
         final AruVisitor<?> visitor
     ) {
-        writeBasicAdders(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
+        writeLoopDelegatingMultipleOperators(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
     }
+
+    /**
+     * Write "removeAll" methods to the builder that is nullable and inherits the type passed to it
+     */
+    public void writeNullableAutoRemoveManyToBuilder(
+        final AnalysedComponent component,
+        final ToBeBuilt builder,
+        final TypeName innerType,
+        final String singleRemoveMethodName,
+        final String addAllMethodName,
+        final AruVisitor<?> visitor
+    ) {
+        writeLoopDelegatingMultipleOperators(component, builder, innerType, singleRemoveMethodName, addAllMethodName, visitor);
+    }
+
+    /**
+     * Write a "remove" method in the builder that is nullable and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNullableAutoRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
+
+    /**
+     * Write a "removeIf" method in the builder that is nullable and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNullableAutoRemovePredicate(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
+
+    /**
+     * Write a "retainAll" method in the builder that is nullable and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNullableAutoRetainAll(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
 
     //#endregion
     //#region Nullable, Immutable
@@ -112,6 +147,27 @@ public abstract class CollectionHandler {
     public abstract void writeNullableImmutableAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
 
     /**
+     * Write a "remove" method in the builder that is nullable and results in an immutable result
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNullableImmutableRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
+
+    /**
+     * Write a "removeIf" method in the builder that is nullable and results in an immutable result
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNullableImmutableRemovePredicate(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
+
+    /**
+     * Write a "retainAll" method in the builder that is nullable and results in an immutable result
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNullableImmutableRetainAll(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
+
+    /**
      * Write "addAll" methods to the builder that is nullable and inherits the type passed to it
      */
     public void writeNullableImmutableAddManyToBuilder(
@@ -122,7 +178,21 @@ public abstract class CollectionHandler {
         final String addAllMethodName,
         final AruVisitor<?> visitor
     ) {
-        writeBasicAdders(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
+        writeLoopDelegatingMultipleOperators(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
+    }
+
+    /**
+     * Write "removeAll" methods to the builder that is nullable and inherits the type passed to it
+     */
+    public void writeNullableImmutableRemoveManyToBuilder(
+        final AnalysedComponent component,
+        final ToBeBuilt builder,
+        final TypeName innerType,
+        final String singleRemoveMethodName,
+        final String addAllMethodName,
+        final AruVisitor<?> visitor
+    ) {
+        writeLoopDelegatingMultipleOperators(component, builder, innerType, singleRemoveMethodName, addAllMethodName, visitor);
     }
 
     //#endregion
@@ -155,6 +225,27 @@ public abstract class CollectionHandler {
     public abstract void writeNonNullAutoAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
 
     /**
+     * Write the "remove" method in the builder that is never nullable, but inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNonNullAutoRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
+
+    /**
+     * Write the "removeIf" method in the builder that is never nullable, but inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNonNullAutoRemovePredicate(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
+
+    /**
+     * Write the "retainAll" method in the builder that is never nullable, but inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNonNullAutoRetainAll(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
+
+    /**
      * Write "addAll" methods to the builder that is nullable and inherits the type passed to it
      */
     public void writeNonNullAutoAddManyToBuilder(
@@ -166,7 +257,22 @@ public abstract class CollectionHandler {
         final AruVisitor<?> visitor
     ) {
         writeNonNullCollectionAdder(component, builder, innerType, addAllMethodName, visitor);
-        writeBasicAdders(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
+        writeLoopDelegatingMultipleOperators(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
+    }
+
+    /**
+     * Write "removeAll" methods to the builder that is nullable and inherits the type passed to it
+     */
+    public void writeNonNullAutoRemoveManyToBuilder(
+        final AnalysedComponent component,
+        final ToBeBuilt builder,
+        final TypeName innerType,
+        final String singleRemoveMethodName,
+        final String addAllMethodName,
+        final AruVisitor<?> visitor
+    ) {
+        writeNonNullCollectionRemoveAll(component, builder, innerType, addAllMethodName, visitor);
+        writeLoopDelegatingMultipleOperators(component, builder, innerType, singleRemoveMethodName, addAllMethodName, visitor);
     }
 
     //#endregion
@@ -199,6 +305,27 @@ public abstract class CollectionHandler {
     public abstract void writeNonNullImmutableAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
 
     /**
+     * Write the "remove" method in the builder that is never nullable and results in an immutable result
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNonNullImmutableRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
+
+    /**
+     * Write the "removeIf" method in the builder that is never nullable and results in an immutable result
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNonNullImmutableRemovePredicate(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
+
+    /**
+     * Write the "retainAll" method in the builder that is never nullable and results in an immutable result
+     * <p>
+     * Does not write returns or params
+     */
+    public abstract void writeNonNullImmutableRetainAll(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType);
+
+    /**
      * Write "addAll" methods to the builder that is nullable and inherits the type passed to it
      */
     public void writeNonNullImmutableAddManyToBuilder(
@@ -210,7 +337,22 @@ public abstract class CollectionHandler {
         final AruVisitor<?> visitor
     ) {
         writeNonNullCollectionAdder(component, builder, innerType, addAllMethodName, visitor);
-        writeBasicAdders(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
+        writeLoopDelegatingMultipleOperators(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
+    }
+
+    /**
+     * Write "removeAll" methods to the builder that is nullable and inherits the type passed to it
+     */
+    public void writeNonNullImmutableRemoveManyToBuilder(
+        final AnalysedComponent component,
+        final ToBeBuilt builder,
+        final TypeName innerType,
+        final String singleRemoveMethodName,
+        final String addAllMethodName,
+        final AruVisitor<?> visitor
+    ) {
+        writeNonNullCollectionRemoveAll(component, builder, innerType, addAllMethodName, visitor);
+        writeLoopDelegatingMultipleOperators(component, builder, innerType, singleRemoveMethodName, addAllMethodName, visitor);
     }
 
     //#endregion
@@ -239,22 +381,9 @@ public abstract class CollectionHandler {
 
     //#region Internal defaults that defer to the single adder
 
-    protected static void writeBasicAdders(
+    protected static void writeNonNullCollectionAdder (
         final AnalysedComponent component,
         final ToBeBuilt builder,
-        final TypeName innerType,
-        final String singleAddMethodName,
-        final String addAllMethodName,
-        final AruVisitor<?> visitor
-    ) {
-        writeBasicIterableAdder(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
-        writeBasicIteratorAdder(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
-        writeBasicSpliteratorAdder(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
-    }
-
-    protected static void writeNonNullCollectionAdder (
-        final AnalysedComponent component, 
-        final ToBeBuilt builder, 
         final TypeName innerType,
         final String addAllMethodName,
         final AruVisitor<?> visitor
@@ -266,98 +395,137 @@ public abstract class CollectionHandler {
             .addAnnotation(NOT_NULL)
             .build();
         final MethodSpec.Builder method = builder
-                .createMethod(addAllMethodName, visitor.claimableOperation(), COLLECTION)
-                .addJavadoc("Adds all elements of the provided collection to {@code $L}", fieldName)
-                .addParameter(param)
-                .returns(builder.className())
-                .addAnnotation(NOT_NULL)
-                .beginControlFlow("if ($T.nonNull($L))", OBJECTS, fieldName)
-                .addStatement("this.$L.addAll($L)", fieldName, fieldName)
-                .endControlFlow()
-                .addStatement("return this");
+            .createMethod(addAllMethodName, visitor.claimableOperation(), COLLECTION)
+            .addJavadoc("Adds all elements of the provided collection to {@code $L}", fieldName)
+            .addParameter(param)
+            .returns(builder.className())
+            .addAnnotation(NOT_NULL)
+            .beginControlFlow("if ($T.nonNull($L))", OBJECTS, fieldName)
+            .addStatement("this.$L.addAll($L)", fieldName, fieldName)
+            .endControlFlow()
+            .addStatement("return this");
         AnnotationSupplier.addGeneratedAnnotation(method, visitor);
     }
 
-    protected static void writeBasicIterableAdder(
+    protected static void writeNonNullCollectionRemoveAll (
+        final AnalysedComponent component,
+        final ToBeBuilt builder,
+        final TypeName innerType,
+        final String addAllMethodName,
+        final AruVisitor<?> visitor
+    ) {
+        final String fieldName = component.name();
+        final ParameterizedTypeName paramTn = ParameterizedTypeName.get(COLLECTION, innerType);
+        final ParameterSpec param = ParameterSpec.builder(paramTn, fieldName, Modifier.FINAL)
+            .addJavadoc("A collection to be merged into the collection")
+            .addAnnotation(NOT_NULL)
+            .build();
+        final MethodSpec.Builder method = builder
+            .createMethod(addAllMethodName, visitor.claimableOperation(), COLLECTION)
+            .addJavadoc("Adds all elements of the provided collection to {@code $L}", fieldName)
+            .addParameter(param)
+            .returns(builder.className())
+            .addAnnotation(NOT_NULL)
+            .beginControlFlow("if ($T.nonNull($L))", OBJECTS, fieldName)
+            .addStatement("this.$L.removeAll($L)", fieldName, fieldName)
+            .endControlFlow()
+            .addStatement("return this");
+        AnnotationSupplier.addGeneratedAnnotation(method, visitor);
+    }
+
+    protected static void writeLoopDelegatingMultipleOperators(
+        final AnalysedComponent component,
+        final ToBeBuilt builder,
+        final TypeName innerType,
+        final String singleOperatorMethodName,
+        final String methodName,
+        final AruVisitor<?> visitor
+    ) {
+        writeBasicIterableOperator(component, builder, innerType, singleOperatorMethodName, methodName, visitor);
+        writeBasicIteratorOperator(component, builder, innerType, singleOperatorMethodName, methodName, visitor);
+        writeBasicSpliteratorOperator(component, builder, innerType, singleOperatorMethodName, methodName, visitor);
+    }
+
+    protected static void writeBasicIterableOperator(
         final AnalysedComponent component, 
         final ToBeBuilt builder, 
         final TypeName innerType, 
-        final String singleAddMethodName, 
-        final String addAllMethodName,
+        final String singleOperatorMethodName,
+        final String methodName,
         final AruVisitor<?> visitor
     ) {
         final String fieldName = component.name();
         final ParameterizedTypeName paramTn = ParameterizedTypeName.get(ITERABLE, innerType);
         final ParameterSpec param = ParameterSpec.builder(paramTn, fieldName, Modifier.FINAL)
-            .addJavadoc("An iterable to be merged into the collection")
+            .addJavadoc("An iterable to be operated on with the collection")
             .addAnnotation(NOT_NULL)
             .build();
         final MethodSpec.Builder method = builder
-                .createMethod(addAllMethodName, visitor.claimableOperation(), ITERABLE)
-                .addJavadoc("Adds all elements of the provided iterable to {@code $L}", fieldName)
+                .createMethod(methodName, visitor.claimableOperation(), ITERABLE)
+                .addJavadoc("Operates on all elements of the provided iterable with {@code $L}", fieldName)
                 .addParameter(param)
                 .returns(builder.className())
                 .addAnnotation(NOT_NULL)
                 .beginControlFlow("if ($T.nonNull($L))", OBJECTS, fieldName)
-                .beginControlFlow("for (final $T __addable : $L)", innerType, fieldName)
-                .addStatement("this.$L(__addable)", singleAddMethodName)
+                .beginControlFlow("for (final $T __single : $L)", innerType, fieldName)
+                .addStatement("this.$L(__single)", singleOperatorMethodName)
                 .endControlFlow()
                 .endControlFlow()
                 .addStatement("return this");
         AnnotationSupplier.addGeneratedAnnotation(method, visitor);
     }
 
-    protected static void writeBasicIteratorAdder(
+    protected static void writeBasicIteratorOperator(
         final AnalysedComponent component, 
         final ToBeBuilt builder, 
         final TypeName innerType, 
-        final String singleAddMethodName, 
-        final String addAllMethodName,
+        final String singleOperatorMethodName,
+        final String methodName,
         final AruVisitor<?> visitor
     ) {
         final String fieldName = component.name();
         final ParameterizedTypeName paramTn = ParameterizedTypeName.get(ITERATOR, innerType);
         final ParameterSpec param = ParameterSpec.builder(paramTn, fieldName, Modifier.FINAL)
-            .addJavadoc("An iterator to be merged into the collection")
+            .addJavadoc("An iterator to be operated on with the collection")
             .addAnnotation(NOT_NULL)
             .build();
         final MethodSpec.Builder method = builder
-                .createMethod(addAllMethodName, visitor.claimableOperation(), ITERATOR)
-                .addJavadoc("Adds all elements of the provided iterator to {@code $L}", fieldName)
+                .createMethod(methodName, visitor.claimableOperation(), ITERATOR)
+                .addJavadoc("Operates on all elements of the provided iterator with {@code $L}", fieldName)
                 .addParameter(param)
                 .returns(builder.className())
                 .addAnnotation(NOT_NULL)
                 .beginControlFlow("if ($T.nonNull($L))", OBJECTS, fieldName)
                 .beginControlFlow("while($L.hasNext())", fieldName)
-                .addStatement("this.$L($L.next())", singleAddMethodName, fieldName)
+                .addStatement("this.$L($L.next())", singleOperatorMethodName, fieldName)
                 .endControlFlow()
                 .endControlFlow()
                 .addStatement("return this");
         AnnotationSupplier.addGeneratedAnnotation(method, visitor);
     }
 
-    protected static void writeBasicSpliteratorAdder(
+    protected static void writeBasicSpliteratorOperator(
         final AnalysedComponent component, 
         final ToBeBuilt builder, 
         final TypeName innerType, 
-        final String singleAddMethodName, 
-        final String addAllMethodName,
+        final String singleOperatorMethodName,
+        final String methodName,
         final AruVisitor<?> visitor
     ) {
         final String fieldName = component.name();
         final ParameterizedTypeName paramTn = ParameterizedTypeName.get(SPLITERATOR, innerType);
         final ParameterSpec param = ParameterSpec.builder(paramTn, fieldName, Modifier.FINAL)
-            .addJavadoc("A spliterator to be merged into the collection")
+            .addJavadoc("A spliterator to be operated on with the collection")
             .addAnnotation(NOT_NULL)
             .build();
         final MethodSpec.Builder method = builder
-                .createMethod(addAllMethodName, visitor.claimableOperation(), SPLITERATOR)
-                .addJavadoc("Adds all elements of the provided spliterator to {@code $L}", fieldName)
+                .createMethod(methodName, visitor.claimableOperation(), SPLITERATOR)
+                .addJavadoc("Operates on all elements of the provided spliterator with {@code $L}", fieldName)
                 .addParameter(param)
                 .returns(builder.className())
                 .addAnnotation(NOT_NULL)
                 .beginControlFlow("if ($T.nonNull($L))", OBJECTS, fieldName)
-                .addStatement("$L.forEachRemaining(this::$L)", fieldName, singleAddMethodName)
+                .addStatement("$L.forEachRemaining(this::$L)", fieldName, singleOperatorMethodName)
                 .endControlFlow()
                 .addStatement("return this");
         AnnotationSupplier.addGeneratedAnnotation(method, visitor);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/CollectionHandlerHelper.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/CollectionHandlerHelper.java
@@ -58,9 +58,40 @@ public sealed interface CollectionHandlerHelper permits
     void writeAddSingle(final MethodSpec.Builder methodBuilder);
 
     /**
+     * Write the "remove single"
+     * <p>
+     * Does not write the returns or the params
+     */
+    void writeRemoveSingle(final MethodSpec.Builder methodBuilder);
+
+    /**
+     * Write the "removeIf"
+     * <p>
+     * Does not write the returns or the params
+     */
+    void writeRemovePredicate(final MethodSpec.Builder methodBuilder);
+
+    /**
+     * Write the "retainAll"
+     * <p>
+     * Does not write the returns or the params
+     */
+    void writeRetainAll(final MethodSpec.Builder methodBuilder);
+
+    /**
      * Write "addAll" methods to the builder
      */
     void writeAddMany(
+        final BuilderClass builderClass,
+        final String singleAdderName,
+        final String addAllMethodName,
+        final AruVisitor<?> visitor
+    );
+
+    /**
+     * Write "removeAll" methods to the builder
+     */
+    void writeRemoveMany(
         final BuilderClass builderClass,
         final String singleAdderName,
         final String addAllMethodName,

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/StandardCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/StandardCollectionHandler.java
@@ -93,6 +93,36 @@ public abstract class StandardCollectionHandler extends CollectionHandler {
     }
 
     @Override
+    public void writeNullableAutoRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        methodBuilder.beginControlFlow("if ($T.isNull(this.$L))", OBJECTS, component.name())
+            .addStatement("this.$L = new $T<$T>()", component.name(), mutableClassName, innerType)
+            .nextControlFlow("else if (!(this.$L instanceof $T))", component.name(), mutableClassName)
+            .addStatement("this.$L = new $T<$T>(this.$L)", component.name(), mutableClassName, innerType, component.name())
+            .endControlFlow()
+            .addStatement("this.$L.remove($L)", component.name(), component.name());
+    }
+
+    @Override
+    public void writeNullableAutoRemovePredicate(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        methodBuilder.beginControlFlow("if ($T.isNull(this.$L))", OBJECTS, component.name())
+            .addStatement("this.$L = new $T<$T>()", component.name(), mutableClassName, innerType)
+            .nextControlFlow("else if (!(this.$L instanceof $T))", component.name(), mutableClassName)
+            .addStatement("this.$L = new $T<$T>(this.$L)", component.name(), mutableClassName, innerType, component.name())
+            .endControlFlow()
+            .addStatement("this.$L.removeIf($L)", component.name(), component.name());
+    }
+
+    @Override
+    public void writeNullableAutoRetainAll(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        methodBuilder.beginControlFlow("if ($T.isNull(this.$L))", OBJECTS, component.name())
+            .addStatement("this.$L = new $T<$T>()", component.name(), mutableClassName, innerType)
+            .nextControlFlow("else if (!(this.$L instanceof $T))", component.name(), mutableClassName)
+            .addStatement("this.$L = new $T<$T>(this.$L)", component.name(), mutableClassName, innerType, component.name())
+            .endControlFlow()
+            .addStatement("this.$L.retainAll($L)", component.name(), component.name());
+    }
+
+    @Override
     public void writeNullableImmutableGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
         if (classNameOnComponent.equals(immutableClassName)) {
             methodBuilder.beginControlFlow("if ($T.isNull(this.$L))", OBJECTS, component.name())
@@ -110,6 +140,21 @@ public abstract class StandardCollectionHandler extends CollectionHandler {
     @Override
     public void writeNullableImmutableAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
         writeNullableAutoAddSingle(component, methodBuilder, innerType);
+    }
+
+    @Override
+    public void writeNullableImmutableRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        writeNullableAutoRemoveSingle(component, methodBuilder, innerType);
+    }
+
+    @Override
+    public void writeNullableImmutableRemovePredicate(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        writeNullableAutoRemovePredicate(component, methodBuilder, innerType);
+    }
+
+    @Override
+    public void writeNullableImmutableRetainAll(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        writeNullableAutoRetainAll(component, methodBuilder, innerType);
     }
 
     @Override
@@ -142,6 +187,24 @@ public abstract class StandardCollectionHandler extends CollectionHandler {
     }
 
     @Override
+    public void writeNonNullAutoRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        final String name = component.name();
+        methodBuilder.addStatement("this.$L.remove($L)", name, name);
+    }
+
+    @Override
+    public void writeNonNullAutoRemovePredicate(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        final String name = component.name();
+        methodBuilder.addStatement("this.$L.removeIf($L)", name, name);
+    }
+
+    @Override
+    public void writeNonNullAutoRetainAll(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        final String name = component.name();
+        methodBuilder.addStatement("this.$L.retainAll($L)", name, name);
+    }
+
+    @Override
     public void writeNonNullImmutableGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
         // The field in the builder is also NonNull in this case, so no need for null check
         convertToImmutable(methodBuilder, "this." + component.name(), "___immutable", innerType);
@@ -158,6 +221,21 @@ public abstract class StandardCollectionHandler extends CollectionHandler {
     @Override
     public void writeNonNullImmutableAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
         writeNonNullAutoAddSingle(component, methodBuilder, innerType);
+    }
+
+    @Override
+    public void writeNonNullImmutableRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        writeNonNullAutoRemoveSingle(component, methodBuilder, innerType);
+    }
+
+    @Override
+    public void writeNonNullImmutableRemovePredicate(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        writeNonNullAutoRemovePredicate(component, methodBuilder, innerType);
+    }
+
+    @Override
+    public void writeNonNullImmutableRetainAll(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        writeNonNullAutoRetainAll(component, methodBuilder, innerType);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/eclipse/EclipseCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/eclipse/EclipseCollectionHandler.java
@@ -93,8 +93,8 @@ public sealed abstract class EclipseCollectionHandler extends StandardCollection
             final AruVisitor<?> visitor
     ) {
         writeEclipseIterableAdder(component, builder, innerType, singleAddMethodName, visitor);
-        CollectionHandler.writeBasicIteratorAdder(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
-        CollectionHandler.writeBasicSpliteratorAdder(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
+        CollectionHandler.writeBasicIteratorOperator(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
+        CollectionHandler.writeBasicSpliteratorOperator(component, builder, innerType, singleAddMethodName, addAllMethodName, visitor);
     }
 
     protected void writeEclipseIterableAdder(

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/list/StackCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/list/StackCollectionHandler.java
@@ -23,4 +23,28 @@ public final class StackCollectionHandler extends ListCollectionHandler {
             .endControlFlow()
             .addStatement("this.$L.add($L)", component.name(), component.name());
     }
+
+    @Override
+    public void writeNullableAutoRemoveSingle(AnalysedComponent component, Builder methodBuilder, TypeName innerType) {
+        methodBuilder.beginControlFlow("if ($T.isNull(this.$L))", OBJECTS, component.name())
+            .addStatement("this.$L = new $T<$T>()", component.name(), mutableClassName, innerType)
+            .endControlFlow()
+            .addStatement("this.$L.remove($L)", component.name(), component.name());
+    }
+
+    @Override
+    public void writeNullableAutoRemovePredicate(AnalysedComponent component, Builder methodBuilder, TypeName innerType) {
+        methodBuilder.beginControlFlow("if ($T.isNull(this.$L))", OBJECTS, component.name())
+            .addStatement("this.$L = new $T<$T>()", component.name(), mutableClassName, innerType)
+            .endControlFlow()
+            .addStatement("this.$L.removeIf($L)", component.name(), component.name());
+    }
+
+    @Override
+    public void writeNullableAutoRetainAll(AnalysedComponent component, Builder methodBuilder, TypeName innerType) {
+        methodBuilder.beginControlFlow("if ($T.isNull(this.$L))", OBJECTS, component.name())
+            .addStatement("this.$L = new $T<$T>()", component.name(), mutableClassName, innerType)
+            .endControlFlow()
+            .addStatement("this.$L.retainAll($L)", component.name(), component.name());
+    }
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/EnumSetCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/EnumSetCollectionHandler.java
@@ -42,6 +42,36 @@ public final class EnumSetCollectionHandler extends SetCollectionHandler {
             .addStatement("this.$L.add($L)", component.name(), component.name());
     }
 
+    public static void nullableAutoRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        methodBuilder.addStatement("$T.requireNonNull($L, $S)", OBJECTS, component.name(), "Cannot add a null item to a set of enums")
+            .beginControlFlow("if ($T.isNull(this.$L))", OBJECTS, component.name())
+            .addStatement("this.$L = $T.noneOf($T.class)", component.name(), ENUM_SET, innerType)
+            .nextControlFlow("else if (!(this.$L instanceof $T))", component.name(), ENUM_SET)
+            .addStatement("this.$L = $T.copyOf(this.$L)", component.name(), ENUM_SET, component.name())
+            .endControlFlow()
+            .addStatement("this.$L.remove($L)", component.name(), component.name());
+    }
+
+    public static void nullableAutoRemovePredicate(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        methodBuilder.addStatement("$T.requireNonNull($L, $S)", OBJECTS, component.name(), "Cannot add a null item to a set of enums")
+            .beginControlFlow("if ($T.isNull(this.$L))", OBJECTS, component.name())
+            .addStatement("this.$L = $T.noneOf($T.class)", component.name(), ENUM_SET, innerType)
+            .nextControlFlow("else if (!(this.$L instanceof $T))", component.name(), ENUM_SET)
+            .addStatement("this.$L = $T.copyOf(this.$L)", component.name(), ENUM_SET, component.name())
+            .endControlFlow()
+            .addStatement("this.$L.removeIf($L)", component.name(), component.name());
+    }
+
+    public static void nullableAutoRetainAll(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        methodBuilder.addStatement("$T.requireNonNull($L, $S)", OBJECTS, component.name(), "Cannot add a null item to a set of enums")
+            .beginControlFlow("if ($T.isNull(this.$L))", OBJECTS, component.name())
+            .addStatement("this.$L = $T.noneOf($T.class)", component.name(), ENUM_SET, innerType)
+            .nextControlFlow("else if (!(this.$L instanceof $T))", component.name(), ENUM_SET)
+            .addStatement("this.$L = $T.copyOf(this.$L)", component.name(), ENUM_SET, component.name())
+            .endControlFlow()
+            .addStatement("this.$L.retainAll($L)", component.name(), component.name());
+    }
+
     public static void mergerMethod(final TypeName innerType, final MethodSpec.Builder methodBuilder, final ClassName classNameOnComponent) {
         final ParameterizedTypeName paramTypeName = ParameterizedTypeName.get(classNameOnComponent, innerType);
         final ParameterSpec paramA = ParameterSpec.builder(paramTypeName, "elA", Modifier.FINAL)
@@ -105,6 +135,21 @@ public final class EnumSetCollectionHandler extends SetCollectionHandler {
     @Override
     public void writeNullableAutoAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
         EnumSetCollectionHandler.nullableAutoAddSingle(component, methodBuilder, innerType);
+    }
+
+    @Override
+    public void writeNullableAutoRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        EnumSetCollectionHandler.nullableAutoRemoveSingle(component, methodBuilder, innerType);
+    }
+
+    @Override
+    public void writeNullableAutoRemovePredicate(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        EnumSetCollectionHandler.nullableAutoRemovePredicate(component, methodBuilder, innerType);
+    }
+
+    @Override
+    public void writeNullableAutoRetainAll(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        EnumSetCollectionHandler.nullableAutoRetainAll(component, methodBuilder, innerType);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/JustSetOfEnumCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/set/JustSetOfEnumCollectionHandler.java
@@ -51,6 +51,21 @@ public final class JustSetOfEnumCollectionHandler extends SetCollectionHandler {
     }
 
     @Override
+    public void writeNullableAutoRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        EnumSetCollectionHandler.nullableAutoRemoveSingle(component, methodBuilder, innerType);
+    }
+
+    @Override
+    public void writeNullableAutoRemovePredicate(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        EnumSetCollectionHandler.nullableAutoRemovePredicate(component, methodBuilder, innerType);
+    }
+
+    @Override
+    public void writeNullableAutoRetainAll(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName innerType) {
+        EnumSetCollectionHandler.nullableAutoRetainAll(component, methodBuilder, innerType);
+    }
+
+    @Override
     public void writeMergerMethod(final TypeName innerType, final MethodSpec.Builder methodBuilder) {
         EnumSetCollectionHandler.mergerMethod(innerType, methodBuilder, classNameOnComponent);
     }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NonNullAutoCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NonNullAutoCollectionHandler.java
@@ -3,7 +3,6 @@ package io.github.cbarlin.aru.impl.types.collection.wrapper;
 import io.github.cbarlin.aru.core.artifacts.BuilderClass;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
-import io.github.cbarlin.aru.core.types.AnalysedComponent;
 import io.github.cbarlin.aru.core.types.components.AnalysedCollectionComponent;
 import io.github.cbarlin.aru.core.visitors.AruVisitor;
 import io.github.cbarlin.aru.impl.types.collection.CollectionHandler;
@@ -38,8 +37,28 @@ public record NonNullAutoCollectionHandler(
     }
 
     @Override
+    public void writeRemoveSingle(Builder methodBuilder) {
+        handler.writeNonNullAutoRemoveSingle(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
+    public void writeRemovePredicate(Builder methodBuilder) {
+        handler.writeNonNullAutoRemovePredicate(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
+    public void writeRetainAll(Builder methodBuilder) {
+        handler.writeNonNullAutoRetainAll(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
     public void writeAddMany(BuilderClass builderClass, String singleAdderName, String addAllMethodName, AruVisitor<?> visitor) {
         handler.writeNonNullAutoAddManyToBuilder(component, builderClass.delegate(), component.unNestedPrimaryTypeName(), singleAdderName, addAllMethodName, visitor);
+    }
+
+    @Override
+    public void writeRemoveMany(BuilderClass builderClass, String singleAdderName, String addAllMethodName, AruVisitor<?> visitor) {
+        handler.writeNonNullAutoRemoveManyToBuilder(component, builderClass.delegate(), component.unNestedPrimaryTypeName(), singleAdderName, addAllMethodName, visitor);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NonNullImmutableNullCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NonNullImmutableNullCollectionHandler.java
@@ -3,7 +3,6 @@ package io.github.cbarlin.aru.impl.types.collection.wrapper;
 import io.github.cbarlin.aru.core.artifacts.BuilderClass;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
-import io.github.cbarlin.aru.core.types.AnalysedComponent;
 import io.github.cbarlin.aru.core.types.components.AnalysedCollectionComponent;
 import io.github.cbarlin.aru.core.visitors.AruVisitor;
 import io.github.cbarlin.aru.impl.types.collection.CollectionHandler;
@@ -38,8 +37,28 @@ public record NonNullImmutableNullCollectionHandler(
     }
 
     @Override
+    public void writeRemoveSingle(Builder methodBuilder) {
+        handler.writeNonNullImmutableRemoveSingle(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
+    public void writeRemovePredicate(Builder methodBuilder) {
+        handler.writeNonNullImmutableRemovePredicate(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
+    public void writeRetainAll(Builder methodBuilder) {
+        handler.writeNonNullImmutableRetainAll(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
     public void writeAddMany(BuilderClass builderClass, String singleAdderName, String addAllMethodName, AruVisitor<?> visitor) {
         handler.writeNonNullImmutableAddManyToBuilder(component, builderClass.delegate(), component.unNestedPrimaryTypeName(), singleAdderName, addAllMethodName, visitor);
+    }
+
+    @Override
+    public void writeRemoveMany(BuilderClass builderClass, String singleAdderName, String addAllMethodName, AruVisitor<?> visitor) {
+        handler.writeNonNullImmutableRemoveManyToBuilder(component, builderClass.delegate(), component.unNestedPrimaryTypeName(), singleAdderName, addAllMethodName, visitor);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NullableAutoCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NullableAutoCollectionHandler.java
@@ -3,7 +3,6 @@ package io.github.cbarlin.aru.impl.types.collection.wrapper;
 import io.github.cbarlin.aru.core.artifacts.BuilderClass;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
-import io.github.cbarlin.aru.core.types.AnalysedComponent;
 import io.github.cbarlin.aru.core.types.components.AnalysedCollectionComponent;
 import io.github.cbarlin.aru.core.visitors.AruVisitor;
 import io.github.cbarlin.aru.impl.types.collection.CollectionHandler;
@@ -38,8 +37,28 @@ public record NullableAutoCollectionHandler(
     }
 
     @Override
+    public void writeRemoveSingle(Builder methodBuilder) {
+        handler.writeNullableAutoRemoveSingle(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
+    public void writeRemovePredicate(Builder methodBuilder) {
+        handler.writeNullableAutoRemovePredicate(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
+    public void writeRetainAll(Builder methodBuilder) {
+        handler.writeNullableAutoRetainAll(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
     public void writeAddMany(BuilderClass builderClass, String singleAdderName, String addAllMethodName, AruVisitor<?> visitor) {
         handler.writeNullableAutoAddManyToBuilder(component, builderClass.delegate(), component.unNestedPrimaryTypeName(), singleAdderName, addAllMethodName, visitor);
+    }
+
+    @Override
+    public void writeRemoveMany(BuilderClass builderClass, String singleAdderName, String addAllMethodName, AruVisitor<?> visitor) {
+        handler.writeNullableAutoRemoveManyToBuilder(component, builderClass.delegate(), component.unNestedPrimaryTypeName(), singleAdderName, addAllMethodName, visitor);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NullableImmutableCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/wrapper/NullableImmutableCollectionHandler.java
@@ -3,7 +3,6 @@ package io.github.cbarlin.aru.impl.types.collection.wrapper;
 import io.github.cbarlin.aru.core.artifacts.BuilderClass;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
-import io.github.cbarlin.aru.core.types.AnalysedComponent;
 import io.github.cbarlin.aru.core.types.components.AnalysedCollectionComponent;
 import io.github.cbarlin.aru.core.visitors.AruVisitor;
 import io.github.cbarlin.aru.impl.types.collection.CollectionHandler;
@@ -38,8 +37,28 @@ public record NullableImmutableCollectionHandler(
     }
 
     @Override
+    public void writeRemoveSingle(Builder methodBuilder) {
+        handler.writeNullableImmutableRemoveSingle(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
+    public void writeRemovePredicate(Builder methodBuilder) {
+        handler.writeNullableImmutableRemovePredicate(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
+    public void writeRetainAll(Builder methodBuilder) {
+        handler.writeNullableImmutableRetainAll(component, methodBuilder, component.unNestedPrimaryTypeName());
+    }
+
+    @Override
     public void writeAddMany(BuilderClass builderClass, String singleAdderName, String addAllMethodName, AruVisitor<?> visitor) {
         handler.writeNullableImmutableAddManyToBuilder(component, builderClass.delegate(), component.unNestedPrimaryTypeName(), singleAdderName, addAllMethodName, visitor);
+    }
+
+    @Override
+    public void writeRemoveMany(BuilderClass builderClass, String singleAdderName, String addAllMethodName, AruVisitor<?> visitor) {
+        handler.writeNullableImmutableRemoveManyToBuilder(component, builderClass.delegate(), component.unNestedPrimaryTypeName(), singleAdderName, addAllMethodName, visitor);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/wither/WithRemove.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/wither/WithRemove.java
@@ -1,0 +1,55 @@
+package io.github.cbarlin.aru.impl.wither;
+
+import io.avaje.inject.Component;
+import io.avaje.inject.RequiresBean;
+import io.avaje.inject.RequiresProperty;
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.types.AnalysedRecord;
+import io.github.cbarlin.aru.core.types.components.AnalysedCollectionComponent;
+import io.github.cbarlin.aru.core.types.components.ConstructorComponent;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.types.collection.CollectionHandlerHelper;
+import io.github.cbarlin.aru.impl.wiring.WitherPerComponentScope;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+
+import javax.lang.model.element.Modifier;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.NON_NULL;
+
+@Component
+@WitherPerComponentScope
+@RequiresProperty(value = "createRemoveMethods", equalTo = "true")
+@RequiresBean({CollectionHandlerHelper.class, ConstructorComponent.class, AnalysedCollectionComponent.class})
+public final class WithRemove extends WitherVisitor {
+
+    public WithRemove(final WitherInterface witherInterface, final AnalysedRecord analysedRecord) {
+        super(Constants.Claims.WITHER_WITH_REMOVE, witherInterface, analysedRecord);
+    }
+
+    @Override
+    protected int witherSpecificity() {
+        return 1;
+    }
+
+    @Override
+    protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
+        final String name = analysedComponent.name();
+        final String withMethodName = witherOptionsPrism.withMethodPrefix() + capitalise(builderOptionsPrism.removeMethodPrefix()) + capitalise(name) + builderOptionsPrism.removeMethodSuffix() + witherOptionsPrism.withMethodSuffix();
+        final String builderMethodName = builderOptionsPrism.removeMethodPrefix() + capitalise(name) + builderOptionsPrism.removeMethodSuffix();
+        final MethodSpec.Builder methodBuilder = witherInterface.createMethod(withMethodName, claimableOperation, analysedComponent)
+                .addAnnotation(NON_NULL)
+                .returns(analysedComponent.parentRecord().intendedType())
+                .addModifiers(Modifier.DEFAULT)
+                .addJavadoc("Return a new instance with a different {@code $L} field", name)
+                .addParameter(
+                        ParameterSpec.builder(analysedComponent.typeName(), name, Modifier.FINAL)
+                                .addJavadoc("Items to remove from the collection")
+                                .build()
+                )
+                .addStatement("return this.$L()\n.$L($L)\n.$L()", witherOptionsPrism.convertToBuilder(), builderMethodName, name, builderOptionsPrism.buildMethodName());
+        AnnotationSupplier.addGeneratedAnnotation(methodBuilder, this);
+        return true;
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/wither/WithRetain.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/wither/WithRetain.java
@@ -1,0 +1,63 @@
+package io.github.cbarlin.aru.impl.wither;
+
+import io.avaje.inject.Component;
+import io.avaje.inject.RequiresBean;
+import io.avaje.inject.RequiresProperty;
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.CommonsConstants;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.types.AnalysedRecord;
+import io.github.cbarlin.aru.core.types.components.AnalysedCollectionComponent;
+import io.github.cbarlin.aru.core.types.components.ConstructorComponent;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.types.collection.CollectionHandlerHelper;
+import io.github.cbarlin.aru.impl.wiring.WitherPerComponentScope;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+import javax.lang.model.element.Modifier;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.NON_NULL;
+
+@Component
+@WitherPerComponentScope
+@RequiresProperty(value = "createRetainAllMethod", equalTo = "true")
+@RequiresBean({CollectionHandlerHelper.class, ConstructorComponent.class, AnalysedCollectionComponent.class})
+public final class WithRetain extends WitherVisitor {
+
+    private final AnalysedCollectionComponent acc;
+
+    public WithRetain(final WitherInterface witherInterface, final AnalysedRecord analysedRecord, final AnalysedCollectionComponent acc) {
+        super(Constants.Claims.WITHER_WITH_RETAIN, witherInterface, analysedRecord);
+        this.acc = acc;
+    }
+
+    @Override
+    protected int witherSpecificity() {
+        return 1;
+    }
+
+    @Override
+    protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
+        final String name = analysedComponent.name();
+        final String withMethodName = witherOptionsPrism.withMethodPrefix() + capitalise(builderOptionsPrism.retainMethodPrefix()) + capitalise(name) + builderOptionsPrism.retainMethodSuffix() + witherOptionsPrism.withMethodSuffix();
+        final String builderMethodName = builderOptionsPrism.retainMethodPrefix() + capitalise(name) + builderOptionsPrism.retainMethodSuffix();
+        final TypeName innerType = acc.unNestedPrimaryTypeName();
+        final ParameterizedTypeName ptn = ParameterizedTypeName.get(CommonsConstants.Names.COLLECTION, innerType);
+        final MethodSpec.Builder methodBuilder = witherInterface.createMethod(withMethodName, claimableOperation, analysedComponent)
+                .addAnnotation(NON_NULL)
+                .returns(analysedComponent.parentRecord().intendedType())
+                .addModifiers(Modifier.DEFAULT)
+                .addJavadoc("Return a new instance with a different {@code $L} field", name)
+                .addParameter(
+                        ParameterSpec.builder(ptn, name, Modifier.FINAL)
+                                .addJavadoc("Collection of items to keep in the collection")
+                                .build()
+                )
+                .addStatement("return this.$L()\n.$L($L)\n.$L()", witherOptionsPrism.convertToBuilder(), builderMethodName, name, builderOptionsPrism.buildMethodName());
+        AnnotationSupplier.addGeneratedAnnotation(methodBuilder, this);
+        return true;
+    }
+}

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/PropertyConfigLoader.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/PropertyConfigLoader.java
@@ -52,6 +52,8 @@ public final class PropertyConfigLoader implements ConfigPropertyPlugin {
             prism -> switch (property) {
                 // Default of true means `null` is true, so compare against false
                 case "createAdderMethods" -> Boolean.FALSE.equals(prism.builderOptions().createAdderMethods()) ? FALSE : TRUE;
+                case "createRemoveMethods" -> Boolean.FALSE.equals(prism.builderOptions().createRemoveMethods()) ? FALSE : TRUE;
+                case "createRetainAllMethod" -> Boolean.FALSE.equals(prism.builderOptions().createRetainAllMethod()) ? FALSE : TRUE;
                 case "createAllInterface" -> Boolean.FALSE.equals(prism.createAllInterface()) ? FALSE : TRUE;
                 case "fluent" -> Boolean.FALSE.equals(prism.builderOptions().fluent()) ? FALSE : TRUE;
                 case "concreteSettersForOptional" -> Boolean.FALSE.equals(prism.builderOptions().concreteSettersForOptional()) ? FALSE : TRUE;

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/visitors/CollectionRecordVisitor.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/visitors/CollectionRecordVisitor.java
@@ -45,6 +45,12 @@ public abstract class CollectionRecordVisitor extends RecordVisitor {
             analysedCollectionComponent.settings().prism().builderOptions().adderMethodSuffix();
     }
 
+    protected String removeNameMethodName() {
+        return analysedCollectionComponent.settings().prism().builderOptions().removeMethodPrefix() +
+            capitalise(analysedCollectionComponent.name()) +
+            analysedCollectionComponent.settings().prism().builderOptions().removeMethodSuffix();
+    }
+
     protected String addCnToNameMethodName(final ClassName targetClassName) {
         return analysedCollectionComponent.settings().prism().builderOptions().adderMethodPrefix() + 
             targetClassName.simpleName() + 

--- a/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/CollectionsTests.java
+++ b/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/CollectionsTests.java
@@ -46,11 +46,18 @@ class CollectionsTests {
 
         // OK, lets try and do a diff
         final NonNullableImmutableCollectionBag c = NonNullableImmutableCollectionBagUtils.builder()
+            // Perform remove operations first, which will end up working on empty/null collections...
+            .removeEnumSetOfEnum(AnEnum.TWO)
+            .removeEnumSetOfEnum(en -> !AnEnum.TWO.equals(en))
             .addEnumSetOfEnum(AnEnum.TWO)
+            .removeHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
             .addHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
             .addTreeSetOfString("This is a string!")
+            .removeLinkedListOfString(Stream.of("A").iterator())
+            .removeLinkedListOfString(Stream.of("A").spliterator())
             .addLinkedListOfString(Stream.of("A").iterator())
             .addLinkedListOfString(Stream.of("A").spliterator())
+            .removeStackOfString(List.of("A"))
             .addStackOfString(List.of("A"))
             .build();
         final var diff = NonNullableImmutableCollectionBagUtils.diff(b, c);
@@ -110,6 +117,12 @@ class CollectionsTests {
             NonNullableImmutableCollectionBagUtils.builder()
                 .addSetOfEnum(AnEnum.ONE)
                 .addLinkedListOfString("B")
+                .addLinkedListOfString("C")
+                .removeLinkedListOfString("D")
+                // Test that the predicate is working
+                .removeLinkedListOfString("C"::equals)
+                .addLinkedListOfString("E")
+                .retainAllLinkedListOfString(List.of("A", "A", "B"))
                 .build()
         );
 
@@ -166,11 +179,18 @@ class CollectionsTests {
 
         // OK, lets try and do a diff
         final NonNullableAutoCollectionBag c = NonNullableAutoCollectionBagUtils.builder()
+            // Perform remove operations first, which will end up working on empty/null collections...
+            .removeEnumSetOfEnum(AnEnum.TWO)
+            .removeEnumSetOfEnum(en -> !AnEnum.TWO.equals(en))
             .addEnumSetOfEnum(AnEnum.TWO)
+            .removeHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
             .addHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
             .addTreeSetOfString("This is a string!")
+            .removeLinkedListOfString(Stream.of("A").iterator())
+            .removeLinkedListOfString(Stream.of("A").spliterator())
             .addLinkedListOfString(Stream.of("A").iterator())
             .addLinkedListOfString(Stream.of("A").spliterator())
+            .removeStackOfString(List.of("A"))
             .addStackOfString(List.of("A"))
             .build();
         final var diff = NonNullableAutoCollectionBagUtils.diff(b, c);
@@ -230,6 +250,12 @@ class CollectionsTests {
             NonNullableAutoCollectionBagUtils.builder()
                 .addSetOfEnum(AnEnum.ONE)
                 .addLinkedListOfString("B")
+                .addLinkedListOfString("C")
+                .removeLinkedListOfString("D")
+                // Test that the predicate is working
+                .removeLinkedListOfString("C"::equals)
+                .addLinkedListOfString("E")
+                .retainAllLinkedListOfString(List.of("A", "A", "B"))
                 .build()
         );
 
@@ -281,11 +307,18 @@ class CollectionsTests {
 
         // OK, lets try and do a diff
         final NullableImmutableCollectionBag c = NullableImmutableCollectionBagUtils.builder()
+            // Perform remove operations first, which will end up working on empty/null collections...
+            .removeEnumSetOfEnum(AnEnum.TWO)
+            .removeEnumSetOfEnum(en -> !AnEnum.TWO.equals(en))
             .addEnumSetOfEnum(AnEnum.TWO)
+            .removeHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
             .addHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
             .addTreeSetOfString("This is a string!")
+            .removeLinkedListOfString(Stream.of("A").iterator())
+            .removeLinkedListOfString(Stream.of("A").spliterator())
             .addLinkedListOfString(Stream.of("A").iterator())
             .addLinkedListOfString(Stream.of("A").spliterator())
+            .removeStackOfString(List.of("A"))
             .addStackOfString(List.of("A"))
             .build();
         final var diff = NullableImmutableCollectionBagUtils.diff(a, c);
@@ -345,6 +378,12 @@ class CollectionsTests {
             NullableImmutableCollectionBagUtils.builder()
                 .addSetOfEnum(AnEnum.ONE)
                 .addLinkedListOfString("B")
+                .addLinkedListOfString("C")
+                .removeLinkedListOfString("D")
+                // Test that the predicate is working
+                .removeLinkedListOfString("C"::equals)
+                .addLinkedListOfString("E")
+                .retainAllLinkedListOfString(List.of("A", "A", "B"))
                 .build()
         );
 
@@ -395,11 +434,18 @@ class CollectionsTests {
 
         // OK, lets try and do a diff
         final NullableAutoCollectionBag c = NullableAutoCollectionBagUtils.builder()
+            // Perform remove operations first, which will end up working on empty/null collections...
+            .removeEnumSetOfEnum(AnEnum.TWO)
+            .removeEnumSetOfEnum(en -> !AnEnum.TWO.equals(en))
             .addEnumSetOfEnum(AnEnum.TWO)
+            .removeHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
             .addHashSetOfEnum(Set.of(AnEnum.ONE, AnEnum.THREE))
             .addTreeSetOfString("This is a string!")
+            .removeLinkedListOfString(Stream.of("A").iterator())
+            .removeLinkedListOfString(Stream.of("A").spliterator())
             .addLinkedListOfString(Stream.of("A").iterator())
             .addLinkedListOfString(Stream.of("A").spliterator())
+            .removeStackOfString(List.of("A"))
             .addStackOfString(List.of("A"))
             .build();
         final var diff = NullableAutoCollectionBagUtils.diff(a, c);
@@ -459,6 +505,12 @@ class CollectionsTests {
             NullableAutoCollectionBagUtils.builder()
                 .addSetOfEnum(AnEnum.ONE)
                 .addLinkedListOfString("B")
+                .addLinkedListOfString("C")
+                .removeLinkedListOfString("D")
+                // Test that the predicate is working
+                .removeLinkedListOfString("C"::equals)
+                .addLinkedListOfString("E")
+                .retainAllLinkedListOfString(List.of("A", "A", "B"))
                 .build()
         );
 

--- a/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/XmlRecordTest.java
+++ b/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/XmlRecordTest.java
@@ -6,13 +6,21 @@ import org.junit.jupiter.api.Test;
 
 import io.github.cbarlin.aru.tests.xml_util.ConvertToXml;
 
+import java.util.List;
+
 class XmlRecordTest {
     @Test
     void serialTest() {
         final CanXmlTheRecord someRecord = CanXmlTheRecordUtils.builder()
             .someString("ItemA")
+            .addSomeItemsAsElements("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+            .removeSomeItemsAsElements("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+            .addSomeItemsAsElements("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+            .removeSomeItemsAsElements(a -> true)
+            .addSomeItemsAsElements("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
             .addSomeItemsAsElements("ThisIsAnElement")
             .addSomeItemsAsElements("AndThisIsTheSecond")
+            .retainAllSomeItemsAsElements(List.of("AndThisIsTheSecond", "ThisIsAnElement", "I'm not in the collection and I shouldn't end up in it!"))
             .addAnotherObject(
                 b -> b.addSomeItemsAsElements("ThisIsAThirdButItsInside")
                     .someString("ItemB")


### PR DESCRIPTION
Fixes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Builder APIs for collections now support remove(element), removeIf(predicate), removeAll(Iterable), and retainAll(Collection).
  - Added corresponding wither methods to create new instances with items removed or retained.
  - Works across nullable/non-null and auto/immutable collection variants.
  - Eclipse Collections usage supported in the same flows.

- Chores
  - New configuration flags: createRemoveMethods and createRetainAllMethod to enable these APIs.

- Tests
  - Expanded coverage for removal, predicate-based removal, and retain-all across multiple collection types and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->