### PR TITLE
Build out Map handling infrastructure

### DIFF
--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/Constants.java
@@ -26,6 +26,7 @@ public enum Constants {
         public static final ClaimableOperation BUILDER_ALIAS_SETTER = new ClaimableOperation("builderAliasSetter", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_CONCRETE_OPTIONAL = new ClaimableOperation("builderConcreteSetterForOptional", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_FLUENT_SETTER = new ClaimableOperation("builderFluentSetter", FIELD_AND_ACCESSORS);
+        public static final ClaimableOperation BUILDER_MAP_SPECIALISATION = new ClaimableOperation("builderMapSpecialisation", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_REMOVE_ALL_ITERABLE = new ClaimableOperation("builderRemoveAllIterable", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_REMOVE_IF = new ClaimableOperation("builderRemoveIf", FIELD_AND_ACCESSORS);
         public static final ClaimableOperation BUILDER_REMOVE_SINGLE = new ClaimableOperation("builderRemoveSingle", FIELD_AND_ACCESSORS);
@@ -111,6 +112,7 @@ public enum Constants {
         public static final ClassName DATE_TIME_FORMATTER = ClassName.get(JAVA_TIME + ".format","DateTimeFormatter");
         public static final ClassName DEQUE = ClassName.get(JAVA_UTIL, "Deque");
         public static final ClassName ENUM = ClassName.get(JAVA_LANG, "Enum");
+        public static final ClassName ENUM_MAP = ClassName.get(JAVA_UTIL, "EnumMap");
         public static final ClassName ENUM_SET = ClassName.get(JAVA_UTIL, "EnumSet");
         public static final ClassName FUNCTION = ClassName.get(JAVA_UTIL_FUNCTION, "Function");
         public static final ClassName HAS_VALUE = ClassName.get("com.tguzik.traits", "HasValue");
@@ -129,6 +131,7 @@ public enum Constants {
         public static final ClassName MATH = ClassName.get(JAVA_LANG, "Math");
         public static final ClassName NON_NULL = CommonsConstants.Names.NON_NULL;
         public static final ClassName NOT_NULL = CommonsConstants.Names.NOT_NULL;
+        public static final ClassName OBJECT = ClassName.get(JAVA_LANG, "Object");
         public static final ClassName OBJECTS = CommonsConstants.Names.OBJECTS;
         public static final ClassName OFFSET_DATE_TIME = ClassName.get(JAVA_TIME, "OffsetDateTime");
         public static final ClassName PREDICATE = ClassName.get(JAVA_UTIL_FUNCTION, "Predicate");

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapField.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapField.java
@@ -2,7 +2,6 @@ package io.github.cbarlin.aru.impl.builder.map;
 
 import io.avaje.inject.Component;
 import io.avaje.inject.RequiresBean;
-import io.github.cbarlin.aru.core.AnnotationSupplier;
 import io.github.cbarlin.aru.core.CommonsConstants;
 import io.github.cbarlin.aru.core.artifacts.BuilderClass;
 import io.github.cbarlin.aru.core.types.AnalysedComponent;
@@ -11,22 +10,21 @@ import io.github.cbarlin.aru.core.types.components.ConstructorComponent;
 import io.github.cbarlin.aru.core.visitors.RecordVisitor;
 import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
 import io.github.cbarlin.aru.impl.wiring.BuilderPerComponentScope;
-import io.micronaut.sourcegen.javapoet.MethodSpec;
 
 @Component
 @BuilderPerComponentScope
 @RequiresBean({ConstructorComponent.class, MapHandlerHelper.class})
-public final class MapGet extends RecordVisitor {
+public final class MapField extends RecordVisitor {
 
     private final BuilderClass builderClass;
     private final MapHandlerHelper mapHandlerHelper;
 
-    public MapGet(
-            final AnalysedRecord analysedRecord,
-            final BuilderClass builderClass,
-            final MapHandlerHelper mapHandlerHelper
+    public MapField(
+        final AnalysedRecord analysedRecord,
+        final BuilderClass builderClass,
+        final MapHandlerHelper mapHandlerHelper
     ) {
-        super(CommonsConstants.Claims.CORE_BUILDER_GETTER, analysedRecord);
+        super(CommonsConstants.Claims.CORE_BUILDER_FIELD, analysedRecord);
         this.builderClass = builderClass;
         this.mapHandlerHelper = mapHandlerHelper;
     }
@@ -37,12 +35,10 @@ public final class MapGet extends RecordVisitor {
     }
 
     @Override
-    protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
-        final MethodSpec.Builder method = builderClass
-                .createMethod(analysedComponent.name(), claimableOperation, analysedComponent.element());
-        method.addJavadoc("Returns the current value of {@code $L}", analysedComponent.name());
-        mapHandlerHelper.writeGetter(method);
-        AnnotationSupplier.addGeneratedAnnotation(method, this);
+    protected boolean visitComponentImpl(
+        final AnalysedComponent ignored
+    ) {
+        mapHandlerHelper.addField(builderClass.delegate());
         return true;
     }
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapRemove.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapRemove.java
@@ -4,12 +4,12 @@ import io.avaje.inject.Component;
 import io.avaje.inject.RequiresBean;
 import io.avaje.inject.RequiresProperty;
 import io.github.cbarlin.aru.core.AnnotationSupplier;
-import io.github.cbarlin.aru.core.CommonsConstants;
 import io.github.cbarlin.aru.core.artifacts.BuilderClass;
 import io.github.cbarlin.aru.core.types.AnalysedComponent;
 import io.github.cbarlin.aru.core.types.AnalysedRecord;
 import io.github.cbarlin.aru.core.types.components.ConstructorComponent;
 import io.github.cbarlin.aru.core.visitors.RecordVisitor;
+import io.github.cbarlin.aru.impl.Constants;
 import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
 import io.github.cbarlin.aru.impl.wiring.BuilderPerComponentScope;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
@@ -20,17 +20,17 @@ import javax.lang.model.element.Modifier;
 @BuilderPerComponentScope
 @RequiresProperty(value = "createAdderMethods", equalTo = "true")
 @RequiresBean({ConstructorComponent.class, MapHandlerHelper.class})
-public final class MapAdd extends RecordVisitor {
+public final class MapRemove extends RecordVisitor {
 
     private final BuilderClass builderClass;
     private final MapHandlerHelper mapHandlerHelper;
 
-    public MapAdd(
+    public MapRemove(
         final AnalysedRecord analysedRecord,
         final BuilderClass builderClass,
         final MapHandlerHelper mapHandlerHelper
     ) {
-        super(CommonsConstants.Claims.CORE_BUILDER_SINGLE_ITEM_ADDER, analysedRecord);
+        super(Constants.Claims.BUILDER_REMOVE_SINGLE, analysedRecord);
         this.builderClass = builderClass;
         this.mapHandlerHelper = mapHandlerHelper;
     }
@@ -44,27 +44,24 @@ public final class MapAdd extends RecordVisitor {
     protected boolean visitComponentImpl(
         final AnalysedComponent ignored
     ) {
-        final String methodName = addNameMethodName();
-        final MethodSpec.Builder method = builderClass.createMethod(methodName, claimableOperation, mapHandlerHelper.component().element());
-        AnnotationSupplier.addGeneratedAnnotation(method, this);
-        mapHandlerHelper.writeAddSingle(method);
-        method.addJavadoc("Add a singular key/value to the map of {@code $L}", mapHandlerHelper.component().name())
-            .returns(builderClass.className())
-            .addModifiers(Modifier.PUBLIC);
-        if (mapHandlerHelper.nullReplacesNotNull()) {
-            method.addJavadoc("\n<p>\n")
-                    .addJavadoc("Supplying a null value will set the current value to null");
-        } else {
-            method.addJavadoc("\n<p>\n")
-                    .addJavadoc("Supplying a null value won't replace a set value");
-        }
-        method.addStatement("return this");
+        addTwoArgs();
         return true;
     }
 
+    private void addTwoArgs() {
+        final String methodName = addNameMethodName();
+        final MethodSpec.Builder method = builderClass.createMethod(methodName, claimableOperation, mapHandlerHelper.component().element());
+        AnnotationSupplier.addGeneratedAnnotation(method, this);
+        mapHandlerHelper.writeRemoveSingle(method);
+        method.addJavadoc("Remove a singular key/value from the map of {@code $L}", mapHandlerHelper.component().name())
+            .returns(builderClass.className())
+            .addModifiers(Modifier.PUBLIC);
+        method.addStatement("return this");
+    }
+
     private String addNameMethodName() {
-        return analysedRecord.settings().prism().builderOptions().adderMethodPrefix() +
+        return analysedRecord.settings().prism().builderOptions().removeMethodPrefix() +
                 capitalise(mapHandlerHelper.component().name()) +
-                analysedRecord.settings().prism().builderOptions().adderMethodSuffix();
+                analysedRecord.settings().prism().builderOptions().removeMethodSuffix();
     }
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapRemove.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapRemove.java
@@ -44,12 +44,7 @@ public final class MapRemove extends RecordVisitor {
     protected boolean visitComponentImpl(
         final AnalysedComponent ignored
     ) {
-        addTwoArgs();
-        return true;
-    }
-
-    private void addTwoArgs() {
-        final String methodName = addNameMethodName();
+        final String methodName = removeMethodName();
         final MethodSpec.Builder method = builderClass.createMethod(methodName, claimableOperation, mapHandlerHelper.component().element());
         AnnotationSupplier.addGeneratedAnnotation(method, this);
         mapHandlerHelper.writeRemoveSingle(method);
@@ -57,9 +52,10 @@ public final class MapRemove extends RecordVisitor {
             .returns(builderClass.className())
             .addModifiers(Modifier.PUBLIC);
         method.addStatement("return this");
+        return true;
     }
 
-    private String addNameMethodName() {
+    private String removeMethodName() {
         return analysedRecord.settings().prism().builderOptions().removeMethodPrefix() +
                 capitalise(mapHandlerHelper.component().name()) +
                 analysedRecord.settings().prism().builderOptions().removeMethodSuffix();

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapRemove.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapRemove.java
@@ -48,7 +48,7 @@ public final class MapRemove extends RecordVisitor {
         final MethodSpec.Builder method = builderClass.createMethod(methodName, claimableOperation, mapHandlerHelper.component().element());
         AnnotationSupplier.addGeneratedAnnotation(method, this);
         mapHandlerHelper.writeRemoveSingle(method);
-        method.addJavadoc("Remove a singular key/value from the map of {@code $L}", mapHandlerHelper.component().name())
+        method.addJavadoc("Remove a singular key from the map of {@code $L}", mapHandlerHelper.component().name())
             .returns(builderClass.className())
             .addModifiers(Modifier.PUBLIC);
         method.addStatement("return this");

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapSet.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapSet.java
@@ -13,20 +13,22 @@ import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
 import io.github.cbarlin.aru.impl.wiring.BuilderPerComponentScope;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
 
+import javax.lang.model.element.Modifier;
+
 @Component
 @BuilderPerComponentScope
 @RequiresBean({ConstructorComponent.class, MapHandlerHelper.class})
-public final class MapGet extends RecordVisitor {
+public final class MapSet extends RecordVisitor {
 
     private final BuilderClass builderClass;
     private final MapHandlerHelper mapHandlerHelper;
 
-    public MapGet(
+    public MapSet(
             final AnalysedRecord analysedRecord,
             final BuilderClass builderClass,
             final MapHandlerHelper mapHandlerHelper
     ) {
-        super(CommonsConstants.Claims.CORE_BUILDER_GETTER, analysedRecord);
+        super(CommonsConstants.Claims.CORE_BUILDER_SETTER, analysedRecord);
         this.builderClass = builderClass;
         this.mapHandlerHelper = mapHandlerHelper;
     }
@@ -40,9 +42,14 @@ public final class MapGet extends RecordVisitor {
     protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
         final MethodSpec.Builder method = builderClass
                 .createMethod(analysedComponent.name(), claimableOperation, analysedComponent.element());
-        method.addJavadoc("Returns the current value of {@code $L}", analysedComponent.name());
-        mapHandlerHelper.writeGetter(method);
+        final String name = analysedComponent.name();
+        method.addJavadoc("Updates the value of {@code $L}", name)
+                .returns(builderClass.className())
+                .addAnnotation(CommonsConstants.Names.NON_NULL)
+                .addModifiers(Modifier.PUBLIC);
+        mapHandlerHelper.writeSetter(method);
         AnnotationSupplier.addGeneratedAnnotation(method, this);
+        method.addStatement("return this");
         return true;
     }
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapSet.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapSet.java
@@ -47,6 +47,13 @@ public final class MapSet extends RecordVisitor {
                 .returns(builderClass.className())
                 .addAnnotation(CommonsConstants.Names.NON_NULL)
                 .addModifiers(Modifier.PUBLIC);
+        if (mapHandlerHelper.nullReplacesNotNull()) {
+            method.addJavadoc("\n<p>\n")
+                            .addJavadoc("Supplying a null value will clear the current map");
+        } else {
+            method.addJavadoc("\n<p>\n")
+                            .addJavadoc("Supplying a null value won't replace a set value");
+        }
         mapHandlerHelper.writeSetter(method);
         AnnotationSupplier.addGeneratedAnnotation(method, this);
         method.addStatement("return this");

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapSpecialisation.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/builder/map/MapSpecialisation.java
@@ -2,31 +2,30 @@ package io.github.cbarlin.aru.impl.builder.map;
 
 import io.avaje.inject.Component;
 import io.avaje.inject.RequiresBean;
-import io.github.cbarlin.aru.core.AnnotationSupplier;
 import io.github.cbarlin.aru.core.CommonsConstants;
 import io.github.cbarlin.aru.core.artifacts.BuilderClass;
 import io.github.cbarlin.aru.core.types.AnalysedComponent;
 import io.github.cbarlin.aru.core.types.AnalysedRecord;
 import io.github.cbarlin.aru.core.types.components.ConstructorComponent;
 import io.github.cbarlin.aru.core.visitors.RecordVisitor;
+import io.github.cbarlin.aru.impl.Constants;
 import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
 import io.github.cbarlin.aru.impl.wiring.BuilderPerComponentScope;
-import io.micronaut.sourcegen.javapoet.MethodSpec;
 
 @Component
 @BuilderPerComponentScope
 @RequiresBean({ConstructorComponent.class, MapHandlerHelper.class})
-public final class MapGet extends RecordVisitor {
+public final class MapSpecialisation extends RecordVisitor {
 
     private final BuilderClass builderClass;
     private final MapHandlerHelper mapHandlerHelper;
 
-    public MapGet(
-            final AnalysedRecord analysedRecord,
-            final BuilderClass builderClass,
-            final MapHandlerHelper mapHandlerHelper
+    public MapSpecialisation(
+        final AnalysedRecord analysedRecord,
+        final BuilderClass builderClass,
+        final MapHandlerHelper mapHandlerHelper
     ) {
-        super(CommonsConstants.Claims.CORE_BUILDER_GETTER, analysedRecord);
+        super(Constants.Claims.BUILDER_MAP_SPECIALISATION, analysedRecord);
         this.builderClass = builderClass;
         this.mapHandlerHelper = mapHandlerHelper;
     }
@@ -37,12 +36,10 @@ public final class MapGet extends RecordVisitor {
     }
 
     @Override
-    protected boolean visitComponentImpl(final AnalysedComponent analysedComponent) {
-        final MethodSpec.Builder method = builderClass
-                .createMethod(analysedComponent.name(), claimableOperation, analysedComponent.element());
-        method.addJavadoc("Returns the current value of {@code $L}", analysedComponent.name());
-        mapHandlerHelper.writeGetter(method);
-        AnnotationSupplier.addGeneratedAnnotation(method, this);
+    protected boolean visitComponentImpl(
+        final AnalysedComponent ignored
+    ) {
+        mapHandlerHelper.writeSpecialisedMethods(builderClass.delegate(), this);
         return true;
     }
 }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/diff/results/EagerMapDiffResultCreator.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/diff/results/EagerMapDiffResultCreator.java
@@ -7,7 +7,6 @@ import io.github.cbarlin.aru.core.types.AnalysedComponent;
 import io.github.cbarlin.aru.impl.Constants.Claims;
 import io.github.cbarlin.aru.impl.diff.DifferVisitor;
 import io.github.cbarlin.aru.impl.diff.holders.DiffHolder;
-import io.github.cbarlin.aru.impl.types.collection.CollectionHandlerHelper;
 import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
 import io.github.cbarlin.aru.impl.wiring.DiffPerComponentScope;
 import io.micronaut.sourcegen.javapoet.FieldSpec;
@@ -60,7 +59,7 @@ public final class EagerMapDiffResultCreator extends DifferVisitor {
         AnnotationSupplier.addGeneratedAnnotation(changedMethod, this);
         changedMethod.returns(TypeName.BOOLEAN)
             .addComment("If there are no added elements and no removed elements, nothing has changed")
-            .addStatement("return !(this.$L.addedKeys().isEmpty() && this.$L.removedKeys().isEmpty() && this.$L.keysWithDifferentValues.isEmpty())", acc.name(), acc.name(), acc.name())
+            .addStatement("return !(this.$L.addedKeys().isEmpty() && this.$L.removedKeys().isEmpty() && this.$L.keysWithDifferentValues().isEmpty())", acc.name(), acc.name(), acc.name())
             .addJavadoc("Has the $S field changed between the two versions?", acc.name());
 
         final MethodSpec.Builder diffMethod = differResult.createMethod(

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/diff/results/EagerMapDiffResultCreator.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/diff/results/EagerMapDiffResultCreator.java
@@ -1,0 +1,78 @@
+package io.github.cbarlin.aru.impl.diff.results;
+
+import io.avaje.inject.RequiresBean;
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.impl.Constants.Claims;
+import io.github.cbarlin.aru.impl.diff.DifferVisitor;
+import io.github.cbarlin.aru.impl.diff.holders.DiffHolder;
+import io.github.cbarlin.aru.impl.types.collection.CollectionHandlerHelper;
+import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
+import io.github.cbarlin.aru.impl.wiring.DiffPerComponentScope;
+import io.micronaut.sourcegen.javapoet.FieldSpec;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+import jakarta.inject.Singleton;
+
+import javax.lang.model.element.Modifier;
+import java.util.List;
+
+@Singleton
+@DiffPerComponentScope
+@RequiresBean({MapHandlerHelper.class})
+public final class EagerMapDiffResultCreator extends DifferVisitor {
+
+    public EagerMapDiffResultCreator(final DiffHolder diffHolder) {
+        super(Claims.DIFFER_COMPUTE_CHANGE, diffHolder);
+    }
+
+    @Override
+    protected int innerSpecificity() {
+        return 5;
+    }
+
+    @Override
+    protected boolean visitComponentImpl(final AnalysedComponent acc) {
+        final ToBeBuiltRecord innerRecord = collectionDiffRecord(acc);
+        differResult.addField(
+            FieldSpec.builder(innerRecord.className(), acc.name(), Modifier.PRIVATE, Modifier.FINAL)
+                .addJavadoc("Diff of the field named $S", acc.name())
+                .build()
+        );
+        final String methodName = hasChangedStaticMethodName(acc.typeName());
+        for ( final MethodSpec.Builder builder : List.of(differResultRecordConstructor, differResultInterfaceConstructor) ) {
+            logTrace(builder, "$S + $S + $S", List.of("Computing the diff of ", acc.name(), " by using their generated diff utils"));
+            builder.addStatement(
+                "this.$L = $T.$L(original.$L(), updated.$L())",
+                acc.name(),
+                differStaticClass.className(),
+                methodName,
+                acc.name(),
+                acc.name()
+            );
+        }
+
+        final MethodSpec.Builder changedMethod = differResult.createMethod(
+            changedMethodName(acc.name()),
+            claimableOperation
+        ).addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+        AnnotationSupplier.addGeneratedAnnotation(changedMethod, this);
+        changedMethod.returns(TypeName.BOOLEAN)
+            .addComment("If there are no added elements and no removed elements, nothing has changed")
+            .addStatement("return !(this.$L.addedKeys().isEmpty() && this.$L.removedKeys().isEmpty() && this.$L.keysWithDifferentValues.isEmpty())", acc.name(), acc.name(), acc.name())
+            .addJavadoc("Has the $S field changed between the two versions?", acc.name());
+
+        final MethodSpec.Builder diffMethod = differResult.createMethod(
+            diffOptionsPrism.differMethodName() + acc.nameFirstLetterCaps(),
+            claimableOperation
+        ).addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+        AnnotationSupplier.addGeneratedAnnotation(diffMethod, this);
+        diffMethod.returns(innerRecord.className())
+            .addStatement("return this.$L", acc.name())
+            .addJavadoc("Obtains the diff of the $S field", acc.name());
+
+        return true;
+    }
+    
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/diff/utils/MapDiffCreation.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/diff/utils/MapDiffCreation.java
@@ -46,7 +46,7 @@ public final class MapDiffCreation extends DifferVisitor {
         innerRecord.builder()
             .addOriginatingElement(acc.parentRecord().typeElement())
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .addJavadoc("A record containing the difference between two collections");
+            .addJavadoc("A record containing the difference between two maps");
         final MethodSpec.Builder builder = differStaticClass.createMethod(methodName, claimableOperation)
             .addModifiers(Modifier.FINAL, Modifier.STATIC);
         AnnotationSupplier.addGeneratedAnnotation(builder, this);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/diff/utils/MapDiffCreation.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/diff/utils/MapDiffCreation.java
@@ -1,0 +1,56 @@
+package io.github.cbarlin.aru.impl.diff.utils;
+
+import io.avaje.inject.RequiresBean;
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.impl.Constants.Claims;
+import io.github.cbarlin.aru.impl.diff.DifferVisitor;
+import io.github.cbarlin.aru.impl.diff.holders.DiffHolder;
+import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
+import io.github.cbarlin.aru.impl.wiring.DiffPerComponentScope;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import jakarta.inject.Singleton;
+
+import javax.lang.model.element.Modifier;
+import java.util.Set;
+
+@Singleton
+@DiffPerComponentScope
+@RequiresBean({MapHandlerHelper.class})
+public final class MapDiffCreation extends DifferVisitor {
+
+    private final MapHandlerHelper handler;
+    private final Set<String> processedSpecs;
+
+    public MapDiffCreation(final DiffHolder diffHolder, final MapHandlerHelper helper) {
+        super(Claims.DIFFER_UTILS_COMPUTE_CHANGE, diffHolder);
+        this.processedSpecs = diffHolder.staticClass().createdMethods();
+        this.handler = helper;
+    }
+
+    @Override
+    protected int innerSpecificity() {
+        return 5;
+    }
+
+    @Override
+    protected boolean visitComponentImpl(final AnalysedComponent acc) {
+        final String methodName = hasChangedStaticMethodName(acc.typeName());
+        if (!processedSpecs.add(methodName)) {
+            return true;
+        }
+        final ToBeBuiltRecord innerRecord = collectionDiffRecord(acc);
+        handler.addDiffRecordComponents(innerRecord);
+        AnnotationSupplier.addGeneratedAnnotation(innerRecord, this);
+        innerRecord.builder()
+            .addOriginatingElement(acc.parentRecord().typeElement())
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addJavadoc("A record containing the difference between two collections");
+        final MethodSpec.Builder builder = differStaticClass.createMethod(methodName, claimableOperation)
+            .addModifiers(Modifier.FINAL, Modifier.STATIC);
+        AnnotationSupplier.addGeneratedAnnotation(builder, this);
+        handler.writeDifferMethod(builder, innerRecord.className());
+        return true;
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/MapMerge.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/merger/utils/MapMerge.java
@@ -1,0 +1,49 @@
+package io.github.cbarlin.aru.impl.merger.utils;
+
+import io.avaje.inject.RequiresBean;
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.impl.Constants.Claims;
+import io.github.cbarlin.aru.impl.merger.MergerHolder;
+import io.github.cbarlin.aru.impl.merger.MergerVisitor;
+import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
+import io.github.cbarlin.aru.impl.wiring.MergerPerComponentScope;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import jakarta.inject.Singleton;
+
+import javax.lang.model.element.Modifier;
+import java.util.Set;
+
+@Singleton
+@MergerPerComponentScope
+@RequiresBean({MapHandlerHelper.class})
+public final class MapMerge extends MergerVisitor {
+
+    private final Set<String> processedSpecs;
+    private final MapHandlerHelper handler;
+
+    public MapMerge(final MergerHolder mergerHolder, final MapHandlerHelper handler) {
+        super(Claims.MERGER_ADD_FIELD_MERGER_METHOD, mergerHolder);
+        this.processedSpecs = mergerHolder.processedMethods();
+        this.handler = handler;
+    }
+
+    @Override
+    protected int innerSpecificity() {
+        return 3;
+    }
+
+    @Override
+    protected boolean visitComponentImpl(final AnalysedComponent acc) {
+        final String methodName = mergeStaticMethodName(acc.typeName());
+        if (processedSpecs.add(methodName)) {
+            final MethodSpec.Builder method = mergerStaticClass.createMethod(methodName, claimableOperation);
+            method.modifiers.clear();
+            method.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL);
+            handler.writeMergerMethod(method);
+            AnnotationSupplier.addGeneratedAnnotation(method, this);
+        }
+        return true;
+    }
+
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/eclipse/list/EclipseListCollectionHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/collection/eclipse/list/EclipseListCollectionHandler.java
@@ -13,7 +13,7 @@ import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
 import static io.github.cbarlin.aru.impl.Constants.Names.LONG;
 import static io.github.cbarlin.aru.impl.Constants.Names.MATH;
-import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames.ECLIPSE_COLLECTIONS_MAP_ITERABLE;
+import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames.ECLIPSE_COLLECTIONS__MAP_ITERABLE;
 import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames.ECLIPSE_COLLECTIONS__IMMUTABLE_LIST;
 import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames.ECLIPSE_COLLECTIONS__LISTS_FACTORY;
 import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames.ECLIPSE_COLLECTIONS__MUTABLE_LIST;
@@ -32,7 +32,7 @@ public abstract sealed class EclipseListCollectionHandler extends EclipseCollect
 
     @Override
     public final void writeDifferMethod(final TypeName innerType, final MethodSpec.Builder methodBuilder, final ClassName collectionResultRecord) {
-        final ParameterizedTypeName mapPtn = ParameterizedTypeName.get(ECLIPSE_COLLECTIONS_MAP_ITERABLE, innerType, LONG);
+        final ParameterizedTypeName mapPtn = ParameterizedTypeName.get(ECLIPSE_COLLECTIONS__MAP_ITERABLE, innerType, LONG);
         final ParameterizedTypeName listPtn = ParameterizedTypeName.get(ECLIPSE_COLLECTIONS__MUTABLE_LIST, innerType);
         final ParameterizedTypeName setPtn = ParameterizedTypeName.get(ECLIPSE_COLLECTIONS__MUTABLE_SET, innerType);
         final ParameterizedTypeName componentPtn = ParameterizedTypeName.get(classNameOnComponent, innerType);

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/dependencies/DependencyClassNames.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/dependencies/DependencyClassNames.java
@@ -128,6 +128,9 @@ public enum DependencyClassNames {
         ECLIPSE_COLLECTIONS_EXCHANGE__PRIMITIVE_ITERABLE = Map.copyOf(iterableMap);
     }
 
+    public static final ClassName ECLIPSE_COLLECTIONS__MAP_ITERABLE = ClassName.get("org.eclipse.collections.api.map", "MapIterable");
+    public static final ClassName ECLIPSE_COLLECTIONS__IMMUTABLE_MAP = ClassName.get("org.eclipse.collections.api.map", "ImmutableMap");
+    public static final ClassName ECLIPSE_COLLECTIONS__MUTABLE_MAP = ClassName.get("org.eclipse.collections.api.map", "MutableMap");
     public static final ClassName ECLIPSE_COLLECTIONS__IMMUTABLE_LIST = ClassName.get("org.eclipse.collections.api.list", "ImmutableList");
     public static final ClassName ECLIPSE_COLLECTIONS__MUTABLE_LIST = ClassName.get("org.eclipse.collections.api.list", "MutableList");
     public static final ClassName ECLIPSE_COLLECTIONS__IMMUTABLE_SET = ClassName.get("org.eclipse.collections.api.set", "ImmutableSet");
@@ -135,6 +138,7 @@ public enum DependencyClassNames {
 
     public static final ClassName ECLIPSE_COLLECTIONS__SETS_FACTORY = ClassName.get("org.eclipse.collections.api.factory", "Sets");
     public static final ClassName ECLIPSE_COLLECTIONS__LISTS_FACTORY = ClassName.get("org.eclipse.collections.api.factory", "Lists");
+    public static final ClassName ECLIPSE_COLLECTIONS__MAPS_FACTORY = ClassName.get("org.eclipse.collections.api.factory", "Maps");
 
     public static final ClassName ECLIPSE_COLLECTIONS_MAP_ITERABLE = ClassName.get("org.eclipse.collections.api.map", "MapIterable");
     // endregion

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/dependencies/DependencyClassNames.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/dependencies/DependencyClassNames.java
@@ -139,8 +139,6 @@ public enum DependencyClassNames {
     public static final ClassName ECLIPSE_COLLECTIONS__SETS_FACTORY = ClassName.get("org.eclipse.collections.api.factory", "Sets");
     public static final ClassName ECLIPSE_COLLECTIONS__LISTS_FACTORY = ClassName.get("org.eclipse.collections.api.factory", "Lists");
     public static final ClassName ECLIPSE_COLLECTIONS__MAPS_FACTORY = ClassName.get("org.eclipse.collections.api.factory", "Maps");
-
-    public static final ClassName ECLIPSE_COLLECTIONS_MAP_ITERABLE = ClassName.get("org.eclipse.collections.api.map", "MapIterable");
     // endregion
 
     private static String capitalise(final String variableName) {

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/dependencies/EclipseCollectionHandlerFactory.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/dependencies/EclipseCollectionHandlerFactory.java
@@ -33,11 +33,12 @@ import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames
 @RequiresProperty(value = ECLIPSE_COLLECTIONS__PROPERTY, equalTo = "true")
 public final class EclipseCollectionHandlerFactory {
 
+    // Boolean is not a valid key type in Eclipse primitive collections
     private static final TypeName[] MAP_PRIMITIVE_KEY_TYPES = {
-        TypeName.BYTE, TypeName.CHAR, TypeName.SHORT, TypeName.INT, TypeName.LONG, TypeName.CHAR, TypeName.FLOAT, TypeName.DOUBLE
+        TypeName.BYTE, TypeName.CHAR, TypeName.SHORT, TypeName.INT, TypeName.LONG, TypeName.FLOAT, TypeName.DOUBLE
     };
     private static final TypeName[] MAP_PRIMITIVE_VALUE_TYPES = {
-        TypeName.BOOLEAN, TypeName.BYTE, TypeName.CHAR, TypeName.SHORT, TypeName.INT, TypeName.LONG, TypeName.CHAR, TypeName.FLOAT, TypeName.DOUBLE
+        TypeName.BOOLEAN, TypeName.BYTE, TypeName.CHAR, TypeName.SHORT, TypeName.INT, TypeName.LONG, TypeName.FLOAT, TypeName.DOUBLE
     };
 
     @Bean

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/dependencies/EclipseCollectionHandlerFactory.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/dependencies/EclipseCollectionHandlerFactory.java
@@ -10,8 +10,14 @@ import io.github.cbarlin.aru.impl.types.collection.eclipse.list.EclipsePrimitive
 import io.github.cbarlin.aru.impl.types.collection.eclipse.set.EclipseImmutableSet;
 import io.github.cbarlin.aru.impl.types.collection.eclipse.set.EclipseMutableSet;
 import io.github.cbarlin.aru.impl.types.collection.eclipse.set.EclipsePrimitiveSet;
+import io.github.cbarlin.aru.impl.types.maps.eclipse.EclipseMapHandler;
+import io.github.cbarlin.aru.impl.types.maps.eclipse.ImmutableNonPrimitiveMapHandler;
+import io.github.cbarlin.aru.impl.types.maps.eclipse.ImmutablePrimitiveMapHandler;
+import io.github.cbarlin.aru.impl.types.maps.eclipse.MutableNonPrimitiveMapHandler;
+import io.github.cbarlin.aru.impl.types.maps.eclipse.MutablePrimitiveMapHandler;
 import io.github.cbarlin.aru.impl.wiring.GlobalScope;
 import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.TypeName;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,6 +32,27 @@ import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames
 @GlobalScope
 @RequiresProperty(value = ECLIPSE_COLLECTIONS__PROPERTY, equalTo = "true")
 public final class EclipseCollectionHandlerFactory {
+
+    private static final TypeName[] MAP_PRIMITIVE_KEY_TYPES = {
+        TypeName.BYTE, TypeName.CHAR, TypeName.SHORT, TypeName.INT, TypeName.LONG, TypeName.CHAR, TypeName.FLOAT, TypeName.DOUBLE
+    };
+    private static final TypeName[] MAP_PRIMITIVE_VALUE_TYPES = {
+        TypeName.BOOLEAN, TypeName.BYTE, TypeName.CHAR, TypeName.SHORT, TypeName.INT, TypeName.LONG, TypeName.CHAR, TypeName.FLOAT, TypeName.DOUBLE
+    };
+
+    @Bean
+    public List<EclipseMapHandler> eclipseMapHandlers() {
+        final List<EclipseMapHandler> result = new ArrayList<>( (MAP_PRIMITIVE_KEY_TYPES.length * MAP_PRIMITIVE_VALUE_TYPES.length * 2) + 2);
+        result.add(new ImmutableNonPrimitiveMapHandler());
+        result.add(new MutableNonPrimitiveMapHandler());
+        for (final TypeName key : MAP_PRIMITIVE_KEY_TYPES) {
+            for (final TypeName value : MAP_PRIMITIVE_VALUE_TYPES) {
+                result.add(new ImmutablePrimitiveMapHandler(key, value));
+                result.add(new MutablePrimitiveMapHandler(key, value));
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
 
     @Bean
     public List<EclipseCollectionHandler> eclipseHandlers() {

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/dependencies/HppcCollectionHandlerFactory.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/dependencies/HppcCollectionHandlerFactory.java
@@ -6,6 +6,7 @@ import io.avaje.inject.RequiresProperty;
 import io.github.cbarlin.aru.impl.types.collection.CollectionHandler;
 import io.github.cbarlin.aru.impl.types.collection.hppc.HppcPrimitiveList;
 import io.github.cbarlin.aru.impl.types.collection.hppc.HppcPrimitiveSet;
+import io.github.cbarlin.aru.impl.types.maps.hppc.HppcMapHandler;
 import io.github.cbarlin.aru.impl.wiring.GlobalScope;
 import io.micronaut.sourcegen.javapoet.ClassName;
 
@@ -20,10 +21,15 @@ import static io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames
 @Factory
 @GlobalScope
 @RequiresProperty(value = HPPC__PROPERTY, equalTo = "true")
-public class HppcCollectionHandlerFactory {
+public final class HppcCollectionHandlerFactory {
 
     // Do not handle `Byte` since there's no "set" version of that to do diffs with...
     private static final List<String> NAMES = List.of("Char", "Double", "Float", "Int", "Long", "Short");
+
+    @Bean
+    List<HppcMapHandler> hppcMapHandlers() {
+        return List.of();
+    }
 
     @Bean
     List<CollectionHandler> hppcCollectionHandlers() {

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/MapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/MapHandler.java
@@ -54,7 +54,7 @@ public interface MapHandler {
      * <p>
      * Does not write returns or params
      */
-     void writeNullableAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull);
+    void writeNullableAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull);
 
     /**
      * Write an "add" method in the builder that is nullable and inherits the type passed to it

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/MapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/MapHandler.java
@@ -73,7 +73,7 @@ public interface MapHandler {
     /**
      * Write any other specialisations that are relevant to the current Map implementation
      */
-    default void writeNullableAutoSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+    default void writeNullableAutoSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
         // No-op
     }
 
@@ -117,7 +117,7 @@ public interface MapHandler {
     /**
      * Write any other specialisations that are relevant to the current Map implementation
      */
-    default void writeNullableImmutableSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+    default void writeNullableImmutableSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
         // No-op
     }
 
@@ -161,7 +161,7 @@ public interface MapHandler {
     /**
      * Write any other specialisations that are relevant to the current Map implementation
      */
-    default void writeNonNullAutoSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+    default void writeNonNullAutoSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
         // No-op
     }
 
@@ -205,7 +205,7 @@ public interface MapHandler {
     /**
      * Write any other specialisations that are relevant to the current Map implementation
      */
-    default void writeNonNullImmutableSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+    default void writeNonNullImmutableSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
         // No-op
     }
 

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/MapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/MapHandler.java
@@ -1,0 +1,236 @@
+package io.github.cbarlin.aru.impl.types.maps;
+
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.visitors.AruVisitor;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+/**
+ * An interface for handlers of various Map types
+ * <p>
+ * This class provides a comprehensive API for handling maps with different
+ *   characteristics: nullable vs non-nullable, and auto (mutable) vs immutable variants.
+ * <p>
+ * Each combination has dedicated methods to ensure type safety and proper handling.
+ */
+public interface MapHandler {
+
+    /**
+     * Determine if this handler can handle this collection type
+     */
+    boolean canHandle(final AnalysedComponent analysedComponent);
+
+    /**
+     * Extract the primary type of the component.
+     * Must be able to do so if {@link #canHandle(AnalysedComponent)} is true
+     */
+    TypeName extractKeyType(final AnalysedComponent analysedComponent);
+
+    /**
+     * Extract the secondary type of the component.
+     * Must be able to do so if {@link #canHandle(AnalysedComponent)} is true
+     */
+    TypeName extractValueType(final AnalysedComponent analysedComponent);
+
+    // region nullable, auto
+
+    /**
+     * Add a nullable field that inherits the type passed into it
+     * <p>
+     * Does not write returns or params
+     */
+    void addNullableAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write the "getter" in the builder that is nullable and inherits the type passed to it
+     */
+    void writeNullableAutoGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write the "setter" in the builder that is nullable and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+     void writeNullableAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull);
+
+    /**
+     * Write an "add" method in the builder that is nullable and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    void writeNullableAutoAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write a "remove" method in the builder that is nullable and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    void writeNullableAutoRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType);
+
+    /**
+     * Write any other specialisations that are relevant to the current Map implementation
+     */
+    default void writeNullableAutoSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+        // No-op
+    }
+
+    // endregion
+
+    // region nullable, immutable
+
+    /**
+     * Add a nullable field that inherits the type passed into it
+     * <p>
+     * Does not write returns or params
+     */
+    void addNullableImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write the "getter" in the builder that is nullable and inherits the type passed to it
+     */
+    void writeNullableImmutableGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write the "setter" in the builder that is nullable and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    void writeNullableImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull);
+
+    /**
+     * Write an "add" method in the builder that is nullable and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    void writeNullableImmutableAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write a "remove" method in the builder that is nullable and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    void writeNullableImmutableRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType);
+
+    /**
+     * Write any other specialisations that are relevant to the current Map implementation
+     */
+    default void writeNullableImmutableSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+        // No-op
+    }
+
+    // endregion
+
+    // region nonNull, auto
+
+    /**
+     * Add a nonNull field that inherits the type passed into it
+     * <p>
+     * Does not write returns or params
+     */
+    void addNonNullAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write the "getter" in the builder that is nonNull and inherits the type passed to it
+     */
+    void writeNonNullAutoGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write the "setter" in the builder that is nonNull and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    void writeNonNullAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull);
+
+    /**
+     * Write an "add" method in the builder that is nonNull and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    void writeNonNullAutoAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write a "remove" method in the builder that is nonNull and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    void writeNonNullAutoRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType);
+
+    /**
+     * Write any other specialisations that are relevant to the current Map implementation
+     */
+    default void writeNonNullAutoSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+        // No-op
+    }
+
+    // endregion
+
+    // region nonNull, immutable
+
+    /**
+     * Add a nonNull field that inherits the type passed into it
+     * <p>
+     * Does not write returns or params
+     */
+    void addNonNullImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write the "getter" in the builder that is nonNull and inherits the type passed to it
+     */
+    void writeNonNullImmutableGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write the "setter" in the builder that is nonNull and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    void writeNonNullImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull);
+
+    /**
+     * Write an "add" method in the builder that is nonNull and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    void writeNonNullImmutableAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType);
+
+    /**
+     * Write a "remove" method in the builder that is nonNull and inherits the type passed to it
+     * <p>
+     * Does not write returns or params
+     */
+    void writeNonNullImmutableRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType);
+
+    /**
+     * Write any other specialisations that are relevant to the current Map implementation
+     */
+    default void writeNonNullImmutableSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+        // No-op
+    }
+
+    // endregion
+
+    //#region Merger, Differ
+
+    /**
+     * Write the method that merges two instances of this collection
+     * <p>
+     * Will write the params and return type
+     */
+    void writeMergerMethod(final TypeName keyType, final TypeName valueType, final MethodSpec.Builder methodBuilder);
+
+    /**
+     * Write the method that creates the diff collection result
+     * <p>
+     * Will write the params and return type
+     */
+    void writeDifferMethod(final TypeName keyType, final TypeName valueType, final MethodSpec.Builder methodBuilder, final ClassName collectionResultRecord);
+
+    /**
+     * Will add components to the record for this type of collection
+     */
+    void addDiffRecordComponents(final TypeName keyType, final TypeName valueType, final ToBeBuiltRecord recordBuilder);
+
+    //#endregion
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/MapHandlerHelper.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/MapHandlerHelper.java
@@ -1,0 +1,88 @@
+package io.github.cbarlin.aru.impl.types.maps;
+
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.visitors.AruVisitor;
+import io.github.cbarlin.aru.impl.types.maps.wrapper.NonNullAutoMapHandler;
+import io.github.cbarlin.aru.impl.types.maps.wrapper.NonNullImmutableMapHandler;
+import io.github.cbarlin.aru.impl.types.maps.wrapper.NullableAutoMapHandler;
+import io.github.cbarlin.aru.impl.types.maps.wrapper.NullableImmutableMapHandler;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+
+/**
+ * A wrapper around a {@link io.github.cbarlin.aru.impl.types.maps.MapHandler} that
+ *   has already had the null/not-null, mutable/immutable, and null-replace/null-noop settings applied
+ */
+public sealed interface MapHandlerHelper
+    permits NonNullAutoMapHandler,
+        NonNullImmutableMapHandler,
+        NullableAutoMapHandler,
+        NullableImmutableMapHandler
+{
+    boolean nullReplacesNotNull();
+
+    /**
+     * The component this is working with
+     */
+    AnalysedComponent component();
+
+    /**
+     * Adds the appropriate field type, including annotations
+     */
+    void addField(final ToBeBuilt addFieldTo);
+
+    /**
+     * Write the getter
+     * <p>
+     * Writes the return type and annotation,
+     *   but not the generated annotation
+     */
+    void writeGetter(final MethodSpec.Builder methodBuilder);
+
+    /**
+     * Write the setter
+     * <p>
+     * Does not write the returns or the params
+     */
+    void writeSetter(final MethodSpec.Builder methodBuilder);
+
+    /**
+     * Write the "add single"
+     * <p>
+     * Does not write the returns or the params
+     */
+    void writeAddSingle(final MethodSpec.Builder methodBuilder);
+
+    /**
+     * Write the "remove single"
+     * <p>
+     * Does not write the returns or the params
+     */
+    void writeRemoveSingle(final MethodSpec.Builder methodBuilder);
+
+    /**
+     * Write any other specialisations that are relevant to the current Map implementation
+     */
+    void writeSpecialisedMethods(final ToBeBuilt toBeBuilt, final AruVisitor<?> visitor);
+
+    /**
+     * Write the method that merges two instances of this collection
+     * <p>
+     * Will write the params and return type
+     */
+    void writeMergerMethod(final MethodSpec.Builder methodBuilder);
+
+    /**
+     * Write the method that creates the diff collection result
+     * <p>
+     * Will write the params and return type
+     */
+    void writeDifferMethod(final MethodSpec.Builder methodBuilder, final ClassName collectionResultRecord);
+
+    /**
+     * Will add components to the record for this type of collection
+     */
+    void addDiffRecordComponents(final ToBeBuiltRecord recordBuilder);
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/MapHandlerHelperFactory.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/MapHandlerHelperFactory.java
@@ -1,0 +1,53 @@
+package io.github.cbarlin.aru.impl.types.maps;
+
+import io.avaje.inject.Bean;
+import io.avaje.inject.Factory;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.types.components.BasicAnalysedComponent;
+import io.github.cbarlin.aru.impl.types.maps.wrapper.NonNullAutoMapHandler;
+import io.github.cbarlin.aru.impl.types.maps.wrapper.NonNullImmutableMapHandler;
+import io.github.cbarlin.aru.impl.types.maps.wrapper.NullableAutoMapHandler;
+import io.github.cbarlin.aru.impl.types.maps.wrapper.NullableImmutableMapHandler;
+import io.github.cbarlin.aru.impl.wiring.BasePerComponentScope;
+import io.github.cbarlin.aru.prism.prison.BuilderOptionsPrism;
+
+import java.util.List;
+import java.util.Optional;
+
+@Factory
+@BasePerComponentScope
+public final class MapHandlerHelperFactory {
+
+    @Bean
+    Optional<MapHandlerHelper> mapHandlerHelper (
+        final BasicAnalysedComponent basicAnalysedComponent,
+        final BuilderOptionsPrism builderOptionsPrism,
+        final List<MapHandler> handlers
+    ) {
+        if (
+            !basicAnalysedComponent.typeName().toString().contains("Map")
+        ) {
+            return Optional.empty();
+        }
+        return handlers.stream()
+                .filter(c -> c.canHandle(basicAnalysedComponent))
+                .findFirst()
+                .map(handler -> createHelper(basicAnalysedComponent, handler, builderOptionsPrism));
+    }
+
+    private static MapHandlerHelper createHelper(final AnalysedComponent component, final MapHandler handler, final BuilderOptionsPrism opts) {
+        final boolean nonNull = !Boolean.FALSE.equals(opts.buildNullCollectionToEmpty());
+        final boolean immutable = !"AUTO".equals(opts.builtCollectionType());
+        final boolean nullReplacesNotNull = (!Boolean.FALSE.equals(opts.nullReplacesNotNull()));
+
+        if (nonNull && immutable) {
+            return new NonNullImmutableMapHandler(component, handler, nullReplacesNotNull);
+        } else if (nonNull) {
+            return new NonNullAutoMapHandler(component, handler, nullReplacesNotNull);
+        } else if (immutable) {
+            return new NullableImmutableMapHandler(component, handler, nullReplacesNotNull);
+        } else {
+            return new NullableAutoMapHandler(component, handler, nullReplacesNotNull);
+        }
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/EclipseMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/EclipseMapHandler.java
@@ -1,0 +1,31 @@
+package io.github.cbarlin.aru.impl.types.maps.eclipse;
+
+import io.github.cbarlin.aru.impl.types.maps.MapHandler;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+/**
+ * Marker interface for handlers for Eclipse collection maps
+ */
+public interface EclipseMapHandler extends MapHandler {
+    static String strName(final TypeName typeName) {
+        if (TypeName.BOOLEAN.equals(typeName)) {
+            return "Boolean";
+        } else if (TypeName.BYTE.equals(typeName)) {
+            return "Byte";
+        } else if (TypeName.SHORT.equals(typeName)) {
+            return "Short";
+        } else if (TypeName.INT.equals(typeName)) {
+            return "Int";
+        } else if (TypeName.LONG.equals(typeName)) {
+            return "Long";
+        } else if (TypeName.CHAR.equals(typeName)) {
+            return "Char";
+        } else if (TypeName.FLOAT.equals(typeName)) {
+            return "Float";
+        } else if (TypeName.DOUBLE.equals(typeName)) {
+            return "Double";
+        } else {
+            return "Object";
+        }
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/ImmutableNonPrimitiveMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/ImmutableNonPrimitiveMapHandler.java
@@ -1,0 +1,367 @@
+package io.github.cbarlin.aru.impl.types.maps.eclipse;
+
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.CommonsConstants;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.visitors.AruVisitor;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.FieldSpec;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.MethodSpec.Builder;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
+import javax.lang.model.element.Modifier;
+
+public final class ImmutableNonPrimitiveMapHandler implements EclipseMapHandler {
+    private static final ClassName iterable = DependencyClassNames.ECLIPSE_COLLECTIONS__MAP_ITERABLE;
+    private static final ClassName immutable = DependencyClassNames.ECLIPSE_COLLECTIONS__IMMUTABLE_MAP;
+    private static final ClassName mutable = DependencyClassNames.ECLIPSE_COLLECTIONS__MUTABLE_MAP;
+    private static final ClassName factory = DependencyClassNames.ECLIPSE_COLLECTIONS__MAPS_FACTORY;
+
+    @Override
+    public boolean canHandle(final AnalysedComponent analysedComponent) {
+        return analysedComponent.typeNameWithoutAnnotations() instanceof final ParameterizedTypeName ptn &&
+            ptn.rawType.withoutAnnotations().equals(immutable) &&
+            ptn.typeArguments.size() == 2;
+    }
+
+    @Override
+    public TypeName extractKeyType(final AnalysedComponent analysedComponent) {
+        return ((ParameterizedTypeName) analysedComponent.typeName()).typeArguments.getFirst().withoutAnnotations();
+    }
+
+    @Override
+    public TypeName extractValueType(final AnalysedComponent analysedComponent) {
+        return ((ParameterizedTypeName) analysedComponent.typeName()).typeArguments.getLast().withoutAnnotations();
+    }
+
+    @Override
+    public void addNullableAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+            ParameterizedTypeName.get(
+                mutable,
+                keyType,
+                valueType
+            ).annotated(CommonsConstants.NULLABLE_ANNOTATION),
+            component.name(),
+            Modifier.PRIVATE
+        ).build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeNullableAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(ParameterizedTypeName.get(immutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .beginControlFlow("if (this.$L != null)", component.name())
+                .addStatement("return this.$L.toImmutable()", component.name())
+                .endControlFlow()
+                .addStatement("return null");
+    }
+
+    @Override
+    public void writeNullableAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        final TypeName param = ParameterizedTypeName.get(iterable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final String name = component.name();
+        methodBuilder.addParameter(
+            ParameterSpec.builder(param, name)
+                .addJavadoc("Replacement value")
+                .build()
+        );
+        if (nullReplacesNotNull) {
+            methodBuilder.beginControlFlow("if ($L == null)", name)
+                    .addStatement("this.$L = null", name)
+                .nextControlFlow("else")
+                    .addStatement("this.$L = $T.mutable.ofMapIterable($L)", name, factory, name)
+                .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                .addStatement("this.$L = $T.mutable.ofMapIterable($L)", name, factory, name)
+                .endControlFlow();
+        }
+    }
+
+    @Override
+    public void writeNullableAutoAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to add to the map")
+                .build();
+        final ParameterSpec value = ParameterSpec.builder(valueType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "value")
+                .addJavadoc("The value to add to the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addParameter(value)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for addition cannot be null")
+                .addStatement("$T.requireNonNull(value, $S)", Constants.Names.OBJECTS, "Supplied value to be added cannot be null")
+                .beginControlFlow("if (this.$L == null)", name)
+                .addStatement("this.$L = $T.mutable.empty()", name, factory)
+                .endControlFlow()
+                .addStatement("this.$L.put(key, value)", name);
+    }
+
+    @Override
+    public void writeNullableAutoRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to remove from the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for removal cannot be null")
+                .beginControlFlow("if (this.$L != null)", name)
+                .addStatement("this.$L.remove(key)", name)
+                .endControlFlow();
+    }
+
+    @Override
+    public void addNullableImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        addNullableAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNullableAutoGetter(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeNullableAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeNullableImmutableAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNullableAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        writeNullableAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void addNonNullAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+                ParameterizedTypeName.get(
+                        mutable,
+                        keyType,
+                        valueType
+                ).annotated(CommonsConstants.NON_NULL_ANNOTATION),
+                component.name(),
+                Modifier.PRIVATE,
+                Modifier.FINAL
+        )
+                .initializer("$T.mutable.empty()", factory)
+                .build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeNonNullAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(ParameterizedTypeName.get(immutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .addStatement("return this.$L.toImmutable()", component.name());
+    }
+
+    @Override
+    public void writeNonNullAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        final TypeName param = ParameterizedTypeName.get(iterable, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        final String name = component.name();
+        methodBuilder.addParameter(
+                ParameterSpec.builder(param, name)
+                        .addJavadoc("Replacement value")
+                        .build()
+        );
+        if (nullReplacesNotNull) {
+            methodBuilder.addStatement("this.$L.clear()", name)
+                    .beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.putAllMapIterable($L)", name, name)
+                    .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.clear()", name)
+                    .addStatement("this.$L.putAllMapIterable($L)", name, name)
+                    .endControlFlow();
+        }
+    }
+
+    @Override
+    public void writeNonNullAutoSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+        writeSetMap(component, visitor, toBeBuilt, keyType, valueType);
+    }
+
+    private void writeSetMap(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+        final MethodSpec.Builder methodBuilder = toBeBuilt.createMethod(component.name(), CommonsConstants.Claims.CORE_BUILDER_SETTER, Constants.Names.MAP)
+                .addAnnotation(CommonsConstants.Names.NON_NULL)
+                .addModifiers(Modifier.PUBLIC);
+        final String name = component.name();
+        methodBuilder.returns(toBeBuilt.className())
+                .addJavadoc("Updates the value of {@code $L}", name);
+        final TypeName param = ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        methodBuilder.addParameter(
+                ParameterSpec.builder(param, name)
+                        .addJavadoc("Replacement value")
+                        .build()
+        );
+        methodBuilder.beginControlFlow("if ($L != null)", name)
+                .addStatement("this.$L.clear()", name)
+                .addStatement("this.$L.putAll($L)", name, name)
+                .endControlFlow()
+                .addStatement("return this");
+        AnnotationSupplier.addGeneratedAnnotation(methodBuilder, visitor);
+    }
+
+    @Override
+    public void writeNonNullImmutableSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+        writeNonNullAutoSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullAutoAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to add to the map")
+                .build();
+        final ParameterSpec value = ParameterSpec.builder(valueType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "value")
+                .addJavadoc("The value to add to the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addParameter(value)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for addition cannot be null")
+                .addStatement("$T.requireNonNull(value, $S)", Constants.Names.OBJECTS, "Supplied value to be added cannot be null")
+                .addStatement("this.$L.put(key, value)", name);
+    }
+
+    @Override
+    public void writeNonNullAutoRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to remove from the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for removal cannot be null")
+                .addStatement("this.$L.remove(key)", name);
+    }
+
+    @Override
+    public void addNonNullImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        addNonNullAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNonNullAutoGetter(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeNonNullAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeNonNullImmutableAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNonNullAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        writeNonNullAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void writeMergerMethod(final TypeName keyType, final TypeName valueType, final Builder methodBuilder) {
+        final TypeName paramTypeName = ParameterizedTypeName.get(immutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final ParameterSpec paramA = ParameterSpec.builder(paramTypeName, "elA", Modifier.FINAL)
+                .addJavadoc("The preferred input")
+                .build();
+
+        final ParameterSpec paramB = ParameterSpec.builder(paramTypeName, "elB", Modifier.FINAL)
+                .addJavadoc("The non-preferred input")
+                .build();
+        methodBuilder.addParameter(paramA)
+                .addParameter(paramB)
+                .returns(paramTypeName)
+                .addJavadoc("Merger for fields of class {@link $T}", paramTypeName)
+                .beginControlFlow("if ($T.isNull(elA) || elA.isEmpty())", Constants.Names.OBJECTS)
+                .addStatement("return elB")
+                .nextControlFlow("else if ($T.isNull(elB) || elB.isEmpty())", Constants.Names.OBJECTS)
+                .addStatement("return elA")
+                .endControlFlow()
+                .addComment("It isn't documented, but the implementation here will create a new map preferring the arguments keys over the callers")
+                .addComment("  so we must then call from our non-preferred")
+                .addStatement("return elB.newWithMapIterable(elA)");
+    }
+
+    @Override
+    public void writeDifferMethod(final TypeName keyType, final TypeName valueType, final Builder methodBuilder, final ClassName collectionResultRecord) {
+        final TypeName paramTypeName = ParameterizedTypeName.get(immutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final TypeName setKey = ParameterizedTypeName.get(DependencyClassNames.ECLIPSE_COLLECTIONS__IMMUTABLE_SET, keyType);
+        methodBuilder.addParameter(ParameterSpec.builder(paramTypeName, "original", Modifier.FINAL).build())
+                .addParameter(ParameterSpec.builder(paramTypeName, "updated", Modifier.FINAL).build())
+                .returns(collectionResultRecord)
+                .addStatement(
+                        "final $T nUpdated = $T.requireNonNullElseGet(updated, () -> $T.immutable.empty())",
+                        paramTypeName.withoutAnnotations(),
+                        Constants.Names.OBJECTS,
+                        factory
+                )
+                .addStatement(
+                        "final $T nOriginal = $T.requireNonNullElseGet(original, () -> $T.immutable.empty())",
+                        paramTypeName.withoutAnnotations(),
+                        Constants.Names.OBJECTS,
+                        factory
+                )
+                .addStatement(
+                        "final $T addedKeys = nUpdated.keysView().reject(nOriginal::containsKey).toImmutableSet()",
+                        setKey
+                )
+                .addStatement(
+                        "final $T removedKeys = nOriginal.keysView().reject(nUpdated::containsKey).toImmutableSet()",
+                        setKey
+                )
+                .addStatement(
+                        "final $T commonKeys = nOriginal.keysView().select(nUpdated::containsKey).toImmutableSet()",
+                        setKey
+                )
+                .addStatement(
+                        "final $T keysWithDifferentValues = commonKeys.reject(k -> Objects.equals(nOriginal.get(k), nUpdated.get(k)))",
+                        setKey
+                )
+                .addStatement(
+                        "final $T keysWithSameValues = commonKeys.newWithoutAll(keysWithDifferentValues)",
+                        setKey
+                )
+                .addStatement(
+                        // Constructor is added, different, same, removed
+                        "return new $T(addedKeys, keysWithDifferentValues, keysWithSameValues, removedKeys)",
+                        collectionResultRecord
+                );
+    }
+
+    @Override
+    public void addDiffRecordComponents(final TypeName keyType, final TypeName valueType, final ToBeBuiltRecord recordBuilder) {
+        final TypeName setKey = ParameterizedTypeName.get(DependencyClassNames.ECLIPSE_COLLECTIONS__IMMUTABLE_SET, keyType).annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        recordBuilder.addParameterSpec(
+                        ParameterSpec.builder(setKey, "addedKeys")
+                                .addJavadoc("The keys that have been added")
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "keysWithDifferentValues")
+                                .addJavadoc("The keys that exist in both maps, but that have different values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "keysWithSameValues")
+                                .addJavadoc("The keys that exist in both maps and that have the same values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "removedKeys")
+                                .addJavadoc("The keys that have been removed")
+                                .build()
+                );
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/ImmutableNonPrimitiveMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/ImmutableNonPrimitiveMapHandler.java
@@ -161,13 +161,13 @@ public final class ImmutableNonPrimitiveMapHandler implements EclipseMapHandler 
 
     @Override
     public void writeNonNullAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
-        methodBuilder.returns(ParameterizedTypeName.get(immutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION))
+        methodBuilder.returns(ParameterizedTypeName.get(immutable, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION))
                 .addStatement("return this.$L.toImmutable()", component.name());
     }
 
     @Override
     public void writeNonNullAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
-        final TypeName param = ParameterizedTypeName.get(iterable, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        final TypeName param = ParameterizedTypeName.get(iterable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
         final String name = component.name();
         methodBuilder.addParameter(
                 ParameterSpec.builder(param, name)
@@ -326,8 +326,8 @@ public final class ImmutableNonPrimitiveMapHandler implements EclipseMapHandler 
                         setKey
                 )
                 .addStatement(
-                        "final $T keysWithDifferentValues = commonKeys.reject(k -> Objects.equals(nOriginal.get(k), nUpdated.get(k)))",
-                        setKey
+                        "final $T keysWithDifferentValues = commonKeys.reject(k -> $T.equals(nOriginal.get(k), nUpdated.get(k)))",
+                        setKey, CommonsConstants.Names.OBJECTS
                 )
                 .addStatement(
                         "final $T keysWithSameValues = commonKeys.newWithoutAll(keysWithDifferentValues)",

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/ImmutableNonPrimitiveMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/ImmutableNonPrimitiveMapHandler.java
@@ -188,34 +188,41 @@ public final class ImmutableNonPrimitiveMapHandler implements EclipseMapHandler 
     }
 
     @Override
-    public void writeNonNullAutoSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
-        writeSetMap(component, visitor, toBeBuilt, keyType, valueType);
+    public void writeNonNullAutoSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeSetMap(component, visitor, toBeBuilt, keyType, valueType, nullReplacesNotNull);
     }
 
-    private void writeSetMap(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
+    private void writeSetMap(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
         final MethodSpec.Builder methodBuilder = toBeBuilt.createMethod(component.name(), CommonsConstants.Claims.CORE_BUILDER_SETTER, Constants.Names.MAP)
                 .addAnnotation(CommonsConstants.Names.NON_NULL)
                 .addModifiers(Modifier.PUBLIC);
         final String name = component.name();
         methodBuilder.returns(toBeBuilt.className())
                 .addJavadoc("Updates the value of {@code $L}", name);
-        final TypeName param = ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        final TypeName param = ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
         methodBuilder.addParameter(
                 ParameterSpec.builder(param, name)
                         .addJavadoc("Replacement value")
                         .build()
         );
-        methodBuilder.beginControlFlow("if ($L != null)", name)
-                .addStatement("this.$L.clear()", name)
-                .addStatement("this.$L.putAll($L)", name, name)
-                .endControlFlow()
-                .addStatement("return this");
+        if (nullReplacesNotNull) {
+            methodBuilder.addStatement("this.$L.clear()", name)
+                    .beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.clear()", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        }
+        methodBuilder.addStatement("return this");
         AnnotationSupplier.addGeneratedAnnotation(methodBuilder, visitor);
     }
 
     @Override
-    public void writeNonNullImmutableSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType) {
-        writeNonNullAutoSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType);
+    public void writeNonNullImmutableSpecialisedMethods(final AnalysedComponent component, final AruVisitor<?> visitor, final ToBeBuilt toBeBuilt, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeNonNullAutoSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType, nullReplacesNotNull);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/ImmutablePrimitiveMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/ImmutablePrimitiveMapHandler.java
@@ -1,0 +1,342 @@
+package io.github.cbarlin.aru.impl.types.maps.eclipse;
+
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.CommonsConstants;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.visitors.AruVisitor;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.FieldSpec;
+import io.micronaut.sourcegen.javapoet.MethodSpec.Builder;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
+import javax.lang.model.element.Modifier;
+
+public final class ImmutablePrimitiveMapHandler implements EclipseMapHandler {
+    private static final String factoryPackage = "org.eclipse.collections.api.factory.primitive";
+    private static final String containerPackage = "org.eclipse.collections.api.map.primitive";
+    private static final String setPackage = "org.eclipse.collections.api.set.primitive";
+    private final ClassName mapParent;
+    private final ClassName immutable;
+    private final ClassName mutable;
+    private final ClassName factory;
+    private final ClassName immutableKeySet;
+    private final ClassName immutableKeySetFactory;
+    private final TypeName key;
+    private final TypeName value;
+
+    public ImmutablePrimitiveMapHandler(
+        final TypeName key,
+        final TypeName value
+    ) {
+        final String keyName = EclipseMapHandler.strName(key);
+        final String valueName = EclipseMapHandler.strName(value);
+        this.key = key;
+        this.value = value;
+        factory = ClassName.get(factoryPackage, keyName + valueName + "Maps");
+        mutable = ClassName.get(containerPackage, "Mutable" + keyName + valueName + "Map");
+        immutable = ClassName.get(containerPackage, "Immutable" + keyName + valueName + "Map");
+        mapParent = ClassName.get(containerPackage, keyName + valueName + "Map");
+        immutableKeySet = ClassName.get(setPackage, "Immutable" + keyName + "Set");
+        immutableKeySetFactory = ClassName.get(factoryPackage, keyName + "Sets");
+    }
+
+    @Override
+    public boolean canHandle(final AnalysedComponent analysedComponent) {
+        return immutable.toString().equals(analysedComponent.typeNameWithoutAnnotations().toString());
+    }
+
+    @Override
+    public TypeName extractKeyType(final AnalysedComponent analysedComponent) {
+        return key;
+    }
+
+    @Override
+    public TypeName extractValueType(final AnalysedComponent analysedComponent) {
+        return value;
+    }
+
+    @Override
+    public void addNullableAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+            mutable.annotated(CommonsConstants.NULLABLE_ANNOTATION),
+            component.name(),
+            Modifier.PRIVATE
+        ).build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeNullableAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(immutable.annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .beginControlFlow("if (this.$L != null)", component.name())
+                .addStatement("return this.$L.toImmutable()", component.name())
+                .endControlFlow()
+                .addStatement("return null");
+    }
+
+    @Override
+    public void writeNullableAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        final TypeName param = mapParent.annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final String name = component.name();
+        methodBuilder.addParameter(
+            ParameterSpec.builder(param, name)
+                .addJavadoc("Replacement value")
+                .build()
+        );
+        if (nullReplacesNotNull) {
+            methodBuilder.beginControlFlow("if ($L == null)", name)
+                    .addStatement("this.$L = null", name)
+                .nextControlFlow("else")
+                    .addStatement("this.$L = $T.mutable.ofAll($L)", name, factory, name)
+                .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                .addStatement("this.$L = $T.mutable.ofAll($L)", name, factory, name)
+                .endControlFlow();
+        }
+    }
+
+    @Override
+    public void writeNullableAutoAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType, "key")
+                .addJavadoc("The key to add to the map")
+                .build();
+        final ParameterSpec value = ParameterSpec.builder(valueType, "value")
+                .addJavadoc("The value to add to the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addParameter(value)
+                .beginControlFlow("if (this.$L == null)", name)
+                .addStatement("this.$L = $T.mutable.empty()", name, factory)
+                .endControlFlow()
+                .addStatement("this.$L.put(key, value)", name);
+    }
+
+    @Override
+    public void writeNullableAutoRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType, "key")
+                .addJavadoc("The key to remove from the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .beginControlFlow("if (this.$L != null)", name)
+                .addStatement("this.$L.remove(key)", name)
+                .endControlFlow();
+    }
+
+    @Override
+    public void addNullableImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        addNullableAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNullableAutoGetter(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeNullableAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeNullableImmutableAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNullableAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        writeNullableAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void addNonNullAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+                mutable.annotated(CommonsConstants.NON_NULL_ANNOTATION),
+                component.name(),
+                Modifier.PRIVATE,
+                Modifier.FINAL
+        )
+                .initializer("$T.mutable.empty()", factory)
+                .build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeNonNullAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(immutable.annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .addStatement("return this.$L.toImmutable()", component.name());
+    }
+
+    @Override
+    public void writeNonNullAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        final TypeName param = mapParent.annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        final String name = component.name();
+        methodBuilder.addParameter(
+                ParameterSpec.builder(param, name)
+                        .addJavadoc("Replacement value")
+                        .build()
+        );
+        if (nullReplacesNotNull) {
+            methodBuilder.addStatement("this.$L.clear()", name)
+                    .beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.clear()", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        }
+    }
+
+    @Override
+    public void writeNonNullAutoAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType, "key")
+                .addJavadoc("The key to add to the map")
+                .build();
+        final ParameterSpec value = ParameterSpec.builder(valueType, "value")
+                .addJavadoc("The value to add to the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addParameter(value)
+                .addStatement("this.$L.put(key, value)", name);
+    }
+
+    @Override
+    public void writeNonNullAutoRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType, "key")
+                .addJavadoc("The key to remove from the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addStatement("this.$L.remove(key)", name);
+    }
+
+    @Override
+    public void addNonNullImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        addNonNullAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNonNullAutoGetter(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeNonNullAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeNonNullImmutableAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNonNullAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        writeNonNullAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void writeMergerMethod(final TypeName keyType, final TypeName valueType, final Builder methodBuilder) {
+        final TypeName paramTypeName = immutable.annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final ParameterSpec paramA = ParameterSpec.builder(paramTypeName, "elA", Modifier.FINAL)
+                .addJavadoc("The preferred input")
+                .build();
+
+        final ParameterSpec paramB = ParameterSpec.builder(paramTypeName, "elB", Modifier.FINAL)
+                .addJavadoc("The non-preferred input")
+                .build();
+        methodBuilder.addParameter(paramA)
+                .addParameter(paramB)
+                .returns(paramTypeName)
+                .addJavadoc("Merger for fields of class {@link $T}", paramTypeName)
+                .beginControlFlow("if ($T.isNull(elA) || elA.isEmpty())", Constants.Names.OBJECTS)
+                .addStatement("return elB")
+                .nextControlFlow("else if ($T.isNull(elB) || elB.isEmpty())", Constants.Names.OBJECTS)
+                .addStatement("return elA")
+                .endControlFlow()
+                .addComment("It isn't documented, but the implementation here will create a new map preferring the arguments keys over the callers")
+                .addComment("  so we must then call from our non-preferred")
+                .addStatement("return $T.mutable.ofAll(elB).withAllKeyValues(elA.keyValuesView()).toImmutable()", factory);
+    }
+
+    @Override
+    public void writeDifferMethod(final TypeName keyType, final TypeName valueType, final Builder methodBuilder, final ClassName collectionResultRecord) {
+        final TypeName paramTypeName = immutable.annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final TypeName setKey = immutableKeySet;
+        methodBuilder.addParameter(ParameterSpec.builder(paramTypeName, "original", Modifier.FINAL).build())
+                .addParameter(ParameterSpec.builder(paramTypeName, "updated", Modifier.FINAL).build())
+                .returns(collectionResultRecord)
+                .addStatement(
+                        "final $T nUpdated = $T.requireNonNullElseGet(updated, () -> $T.immutable.empty())",
+                        paramTypeName.withoutAnnotations(),
+                        Constants.Names.OBJECTS,
+                        factory
+                )
+                .addStatement(
+                        "final $T nOriginal = $T.requireNonNullElseGet(original, () -> $T.immutable.empty())",
+                        paramTypeName.withoutAnnotations(),
+                        Constants.Names.OBJECTS,
+                        factory
+                )
+                .addStatement(
+                        "final $T addedKeys = $T.immutable.ofAll(nUpdated.keysView().reject(nOriginal::containsKey))",
+                        setKey, immutableKeySetFactory
+                )
+                .addStatement(
+                        "final $T removedKeys = $T.immutable.ofAll(nOriginal.keysView().reject(nUpdated::containsKey))",
+                        setKey, immutableKeySetFactory
+                )
+                .addStatement(
+                        "final $T commonKeys = $T.immutable.ofAll(nOriginal.keysView().select(nUpdated::containsKey))",
+                        setKey, immutableKeySetFactory
+                )
+                .addStatement(
+                        "final $T keysWithDifferentValues = commonKeys.reject(k -> Objects.equals(nOriginal.get(k), nUpdated.get(k)))",
+                        setKey
+                )
+                .addStatement(
+                        "final $T keysWithSameValues = commonKeys.newWithoutAll(keysWithDifferentValues)",
+                        setKey
+                )
+                .addStatement(
+                        // Constructor is added, different, same, removed
+                        "return new $T(addedKeys, keysWithDifferentValues, keysWithSameValues, removedKeys)",
+                        collectionResultRecord
+                );
+    }
+
+    @Override
+    public void addDiffRecordComponents(final TypeName keyType, final TypeName valueType, final ToBeBuiltRecord recordBuilder) {
+        final TypeName setKey = immutableKeySet.annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        recordBuilder.addParameterSpec(
+                        ParameterSpec.builder(setKey, "addedKeys")
+                                .addJavadoc("The keys that have been added")
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "keysWithDifferentValues")
+                                .addJavadoc("The keys that exist in both maps, but that have different values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "keysWithSameValues")
+                                .addJavadoc("The keys that exist in both maps and that have the same values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "removedKeys")
+                                .addJavadoc("The keys that have been removed")
+                                .build()
+                );
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/ImmutablePrimitiveMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/ImmutablePrimitiveMapHandler.java
@@ -170,13 +170,13 @@ public final class ImmutablePrimitiveMapHandler implements EclipseMapHandler {
 
     @Override
     public void writeNonNullAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
-        methodBuilder.returns(immutable.annotated(CommonsConstants.NULLABLE_ANNOTATION))
+        methodBuilder.returns(immutable.annotated(CommonsConstants.NON_NULL_ANNOTATION))
                 .addStatement("return this.$L.toImmutable()", component.name());
     }
 
     @Override
     public void writeNonNullAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
-        final TypeName param = mapParent.annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        final TypeName param = mapParent.annotated(CommonsConstants.NULLABLE_ANNOTATION);
         final String name = component.name();
         methodBuilder.addParameter(
                 ParameterSpec.builder(param, name)
@@ -301,8 +301,8 @@ public final class ImmutablePrimitiveMapHandler implements EclipseMapHandler {
                         setKey, immutableKeySetFactory
                 )
                 .addStatement(
-                        "final $T keysWithDifferentValues = commonKeys.reject(k -> Objects.equals(nOriginal.get(k), nUpdated.get(k)))",
-                        setKey
+                        "final $T keysWithDifferentValues = commonKeys.reject(k -> $T.equals(nOriginal.get(k), nUpdated.get(k)))",
+                        setKey, CommonsConstants.Names.OBJECTS
                 )
                 .addStatement(
                         "final $T keysWithSameValues = commonKeys.newWithoutAll(keysWithDifferentValues)",

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutableNonPrimitiveMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutableNonPrimitiveMapHandler.java
@@ -1,11 +1,9 @@
 package io.github.cbarlin.aru.impl.types.maps.eclipse;
 
-import io.github.cbarlin.aru.core.AnnotationSupplier;
 import io.github.cbarlin.aru.core.CommonsConstants;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
 import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
 import io.github.cbarlin.aru.core.types.AnalysedComponent;
-import io.github.cbarlin.aru.core.visitors.AruVisitor;
 import io.github.cbarlin.aru.impl.Constants;
 import io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames;
 import io.micronaut.sourcegen.javapoet.ClassName;
@@ -17,6 +15,11 @@ import io.micronaut.sourcegen.javapoet.TypeName;
 import javax.lang.model.element.Modifier;
 
 public final class MutableNonPrimitiveMapHandler implements EclipseMapHandler {
+    /*
+    A reminder that the explicit type the user has entered is "MutableMap" - so we *must* return mutable variants
+        in our "immutable" methods
+     */
+
     private static final ClassName iterable = DependencyClassNames.ECLIPSE_COLLECTIONS__MAP_ITERABLE;
     private static final ClassName mutable = DependencyClassNames.ECLIPSE_COLLECTIONS__MUTABLE_MAP;
     private static final ClassName factory = DependencyClassNames.ECLIPSE_COLLECTIONS__MAPS_FACTORY;
@@ -163,23 +166,30 @@ public final class MutableNonPrimitiveMapHandler implements EclipseMapHandler {
 
     @Override
     public void writeNonNullAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
-        methodBuilder.returns(ParameterizedTypeName.get(mutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION))
+        methodBuilder.returns(ParameterizedTypeName.get(mutable, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION))
                 .addStatement("return this.$L", component.name());
     }
 
     @Override
     public void writeNonNullAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
         final String name = component.name();
-        final TypeName param = ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        final TypeName param = ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
         methodBuilder.addParameter(
                 ParameterSpec.builder(param, name)
                         .addJavadoc("Replacement value")
                         .build()
         );
-        methodBuilder.beginControlFlow("if ($L != null)", name)
-                .addStatement("this.$L.clear()", name)
-                .addStatement("this.$L.putAll($L)", name, name)
-                .endControlFlow();
+        if (nullReplacesNotNull) {
+            methodBuilder.addStatement("this.$L.clear()", name)
+                    .beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.clear()", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        }
     }
 
     @Override
@@ -291,8 +301,8 @@ public final class MutableNonPrimitiveMapHandler implements EclipseMapHandler {
                         setKey
                 )
                 .addStatement(
-                        "final $T keysWithDifferentValues = commonKeys.reject(k -> Objects.equals(nOriginal.get(k), nUpdated.get(k)))",
-                        setKey
+                        "final $T keysWithDifferentValues = commonKeys.reject(k -> $T.equals(nOriginal.get(k), nUpdated.get(k)))",
+                        setKey, CommonsConstants.Names.OBJECTS
                 )
                 .addStatement(
                         "final $T keysWithSameValues = commonKeys.newWithoutAll(keysWithDifferentValues)",

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutableNonPrimitiveMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutableNonPrimitiveMapHandler.java
@@ -1,0 +1,332 @@
+package io.github.cbarlin.aru.impl.types.maps.eclipse;
+
+import io.github.cbarlin.aru.core.AnnotationSupplier;
+import io.github.cbarlin.aru.core.CommonsConstants;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.visitors.AruVisitor;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.FieldSpec;
+import io.micronaut.sourcegen.javapoet.MethodSpec.Builder;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
+import javax.lang.model.element.Modifier;
+
+public final class MutableNonPrimitiveMapHandler implements EclipseMapHandler {
+    private static final ClassName iterable = DependencyClassNames.ECLIPSE_COLLECTIONS__MAP_ITERABLE;
+    private static final ClassName mutable = DependencyClassNames.ECLIPSE_COLLECTIONS__MUTABLE_MAP;
+    private static final ClassName factory = DependencyClassNames.ECLIPSE_COLLECTIONS__MAPS_FACTORY;
+
+    @Override
+    public boolean canHandle(final AnalysedComponent analysedComponent) {
+        return analysedComponent.typeNameWithoutAnnotations() instanceof final ParameterizedTypeName ptn &&
+            ptn.rawType.withoutAnnotations().equals(mutable) &&
+            ptn.typeArguments.size() == 2;
+    }
+
+    @Override
+    public TypeName extractKeyType(final AnalysedComponent analysedComponent) {
+        return ((ParameterizedTypeName) analysedComponent.typeName()).typeArguments.getFirst().withoutAnnotations();
+    }
+
+    @Override
+    public TypeName extractValueType(final AnalysedComponent analysedComponent) {
+        return ((ParameterizedTypeName) analysedComponent.typeName()).typeArguments.getLast().withoutAnnotations();
+    }
+
+    @Override
+    public void addNullableAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+            ParameterizedTypeName.get(
+                mutable,
+                keyType,
+                valueType
+            ).annotated(CommonsConstants.NULLABLE_ANNOTATION),
+            component.name(),
+            Modifier.PRIVATE
+        ).build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeNullableAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(ParameterizedTypeName.get(mutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .beginControlFlow("if (this.$L != null)", component.name())
+                .addStatement("return this.$L", component.name())
+                .endControlFlow()
+                .addStatement("return null");
+    }
+
+    @Override
+    public void writeNullableAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        final TypeName param = ParameterizedTypeName.get(iterable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final String name = component.name();
+        methodBuilder.addParameter(
+            ParameterSpec.builder(param, name)
+                .addJavadoc("Replacement value")
+                .build()
+        );
+        if (nullReplacesNotNull) {
+            methodBuilder.beginControlFlow("if ($L == null)", name)
+                    .addStatement("this.$L = null", name)
+                .nextControlFlow("else")
+                    .addStatement("this.$L = $T.mutable.ofMapIterable($L)", name, factory, name)
+                .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                .addStatement("this.$L = $T.mutable.ofMapIterable($L)", name, factory, name)
+                .endControlFlow();
+        }
+    }
+
+    @Override
+    public void writeNullableAutoAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to add to the map")
+                .build();
+        final ParameterSpec value = ParameterSpec.builder(valueType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "value")
+                .addJavadoc("The value to add to the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addParameter(value)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for addition cannot be null")
+                .addStatement("$T.requireNonNull(value, $S)", Constants.Names.OBJECTS, "Supplied value to be added cannot be null")
+                .beginControlFlow("if (this.$L == null)", name)
+                .addStatement("this.$L = $T.mutable.empty()", name, factory)
+                .endControlFlow()
+                .addStatement("this.$L.put(key, value)", name);
+    }
+
+    @Override
+    public void writeNullableAutoRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to remove from the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for removal cannot be null")
+                .beginControlFlow("if (this.$L != null)", name)
+                .addStatement("this.$L.remove(key)", name)
+                .endControlFlow();
+    }
+
+    @Override
+    public void addNullableImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        addNullableAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(ParameterizedTypeName.get(mutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .beginControlFlow("if (this.$L != null)", component.name())
+                .addStatement("return $T.mutable.ofMapIterable(this.$L)", factory, component.name())
+                .endControlFlow()
+                .addStatement("return null");
+    }
+
+    @Override
+    public void writeNullableImmutableSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeNullableAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeNullableImmutableAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNullableAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        writeNullableAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void addNonNullAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+                ParameterizedTypeName.get(
+                        mutable,
+                        keyType,
+                        valueType
+                ).annotated(CommonsConstants.NON_NULL_ANNOTATION),
+                component.name(),
+                Modifier.PRIVATE,
+                Modifier.FINAL
+        )
+                .initializer("$T.mutable.empty()", factory)
+                .build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeNonNullAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(ParameterizedTypeName.get(mutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .addStatement("return this.$L", component.name());
+    }
+
+    @Override
+    public void writeNonNullAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        final String name = component.name();
+        final TypeName param = ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        methodBuilder.addParameter(
+                ParameterSpec.builder(param, name)
+                        .addJavadoc("Replacement value")
+                        .build()
+        );
+        methodBuilder.beginControlFlow("if ($L != null)", name)
+                .addStatement("this.$L.clear()", name)
+                .addStatement("this.$L.putAll($L)", name, name)
+                .endControlFlow();
+    }
+
+    @Override
+    public void writeNonNullAutoAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to add to the map")
+                .build();
+        final ParameterSpec value = ParameterSpec.builder(valueType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "value")
+                .addJavadoc("The value to add to the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addParameter(value)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for addition cannot be null")
+                .addStatement("$T.requireNonNull(value, $S)", Constants.Names.OBJECTS, "Supplied value to be added cannot be null")
+                .addStatement("this.$L.put(key, value)", name);
+    }
+
+    @Override
+    public void writeNonNullAutoRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to remove from the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for removal cannot be null")
+                .addStatement("this.$L.remove(key)", name);
+    }
+
+    @Override
+    public void addNonNullImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        addNonNullAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(ParameterizedTypeName.get(mutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .addStatement("return $T.mutable.ofMapIterable(this.$L)", factory, component.name());
+    }
+
+    @Override
+    public void writeNonNullImmutableSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeNonNullAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeNonNullImmutableAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNonNullAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        writeNonNullAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void writeMergerMethod(final TypeName keyType, final TypeName valueType, final Builder methodBuilder) {
+        final TypeName paramTypeName = ParameterizedTypeName.get(mutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final ParameterSpec paramA = ParameterSpec.builder(paramTypeName, "elA", Modifier.FINAL)
+                .addJavadoc("The preferred input")
+                .build();
+
+        final ParameterSpec paramB = ParameterSpec.builder(paramTypeName, "elB", Modifier.FINAL)
+                .addJavadoc("The non-preferred input")
+                .build();
+        methodBuilder.addParameter(paramA)
+                .addParameter(paramB)
+                .returns(paramTypeName)
+                .addJavadoc("Merger for fields of class {@link $T}", paramTypeName)
+                .beginControlFlow("if ($T.isNull(elA) || elA.isEmpty())", Constants.Names.OBJECTS)
+                .addStatement("return elB")
+                .nextControlFlow("else if ($T.isNull(elB) || elB.isEmpty())", Constants.Names.OBJECTS)
+                .addStatement("return elA")
+                .endControlFlow()
+                .addComment("It isn't documented, but the implementation of `withMapIterable` _modifies_ the current collection, preferring")
+                .addComment("  the passed-in value over the calling one, so we call 'from' the non-preferred")
+                .addStatement("return $T.mutable.ofMapIterable(elB).withMapIterable(elA)", factory);
+    }
+
+    @Override
+    public void writeDifferMethod(final TypeName keyType, final TypeName valueType, final Builder methodBuilder, final ClassName collectionResultRecord) {
+        final TypeName paramTypeName = ParameterizedTypeName.get(mutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final TypeName setKey = ParameterizedTypeName.get(DependencyClassNames.ECLIPSE_COLLECTIONS__IMMUTABLE_SET, keyType);
+        methodBuilder.addParameter(ParameterSpec.builder(paramTypeName, "original", Modifier.FINAL).build())
+                .addParameter(ParameterSpec.builder(paramTypeName, "updated", Modifier.FINAL).build())
+                .returns(collectionResultRecord)
+                .addStatement(
+                        "final $T nUpdated = $T.requireNonNullElseGet(updated, () -> $T.mutable.empty())",
+                        paramTypeName.withoutAnnotations(),
+                        Constants.Names.OBJECTS,
+                        factory
+                )
+                .addStatement(
+                        "final $T nOriginal = $T.requireNonNullElseGet(original, () -> $T.mutable.empty())",
+                        paramTypeName.withoutAnnotations(),
+                        Constants.Names.OBJECTS,
+                        factory
+                )
+                .addStatement(
+                        "final $T addedKeys = nUpdated.keysView().reject(nOriginal::containsKey).toImmutableSet()",
+                        setKey
+                )
+                .addStatement(
+                        "final $T removedKeys = nOriginal.keysView().reject(nUpdated::containsKey).toImmutableSet()",
+                        setKey
+                )
+                .addStatement(
+                        "final $T commonKeys = nOriginal.keysView().select(nUpdated::containsKey).toImmutableSet()",
+                        setKey
+                )
+                .addStatement(
+                        "final $T keysWithDifferentValues = commonKeys.reject(k -> Objects.equals(nOriginal.get(k), nUpdated.get(k)))",
+                        setKey
+                )
+                .addStatement(
+                        "final $T keysWithSameValues = commonKeys.newWithoutAll(keysWithDifferentValues)",
+                        setKey
+                )
+                .addStatement(
+                        // Constructor is added, different, same, removed
+                        "return new $T(addedKeys, keysWithDifferentValues, keysWithSameValues, removedKeys)",
+                        collectionResultRecord
+                );
+    }
+
+    @Override
+    public void addDiffRecordComponents(final TypeName keyType, final TypeName valueType, final ToBeBuiltRecord recordBuilder) {
+        final TypeName setKey = ParameterizedTypeName.get(DependencyClassNames.ECLIPSE_COLLECTIONS__IMMUTABLE_SET, keyType).annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        recordBuilder.addParameterSpec(
+                        ParameterSpec.builder(setKey, "addedKeys")
+                                .addJavadoc("The keys that have been added")
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "keysWithDifferentValues")
+                                .addJavadoc("The keys that exist in both maps, but that have different values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "keysWithSameValues")
+                                .addJavadoc("The keys that exist in both maps and that have the same values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "removedKeys")
+                                .addJavadoc("The keys that have been removed")
+                                .build()
+                );
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutableNonPrimitiveMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutableNonPrimitiveMapHandler.java
@@ -226,7 +226,7 @@ public final class MutableNonPrimitiveMapHandler implements EclipseMapHandler {
 
     @Override
     public void writeNonNullImmutableGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
-        methodBuilder.returns(ParameterizedTypeName.get(mutable, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION))
+        methodBuilder.returns(ParameterizedTypeName.get(mutable, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION))
                 .addStatement("return $T.mutable.ofMapIterable(this.$L)", factory, component.name());
     }
 

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutablePrimitiveMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutablePrimitiveMapHandler.java
@@ -231,7 +231,7 @@ public final class MutablePrimitiveMapHandler implements EclipseMapHandler {
 
     @Override
     public void writeNonNullImmutableGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
-        methodBuilder.returns(mutable.annotated(CommonsConstants.NULLABLE_ANNOTATION))
+        methodBuilder.returns(mutable.annotated(CommonsConstants.NON_NULL_ANNOTATION))
                 .addStatement("return $T.mutable.ofAll(this.$L)", factory, component.name());
     }
 

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutablePrimitiveMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutablePrimitiveMapHandler.java
@@ -1,0 +1,336 @@
+package io.github.cbarlin.aru.impl.types.maps.eclipse;
+
+import io.github.cbarlin.aru.core.CommonsConstants;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.types.dependencies.DependencyClassNames;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.FieldSpec;
+import io.micronaut.sourcegen.javapoet.MethodSpec.Builder;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
+import javax.lang.model.element.Modifier;
+
+public final class MutablePrimitiveMapHandler implements EclipseMapHandler {
+    private static final String factoryPackage = "org.eclipse.collections.api.factory.primitive";
+    private static final String containerPackage = "org.eclipse.collections.api.map.primitive";
+    private static final String setPackage = "org.eclipse.collections.api.set.primitive";
+    private final ClassName mapParent;
+    private final ClassName mutable;
+    private final ClassName factory;
+    private final ClassName immutableKeySet;
+    private final ClassName immutableKeySetFactory;
+    private final TypeName key;
+    private final TypeName value;
+
+    public MutablePrimitiveMapHandler(
+            final TypeName key,
+            final TypeName value
+    ) {
+        final String keyName = EclipseMapHandler.strName(key);
+        final String valueName = EclipseMapHandler.strName(value);
+        this.key = key;
+        this.value = value;
+        factory = ClassName.get(factoryPackage, keyName + valueName + "Maps");
+        mutable = ClassName.get(containerPackage, "Mutable" + keyName + valueName + "Map");
+        mapParent = ClassName.get(containerPackage, keyName + valueName + "Map");
+        immutableKeySet = ClassName.get(setPackage, "Immutable" + keyName + "Set");
+        immutableKeySetFactory = ClassName.get(factoryPackage, keyName + "Sets");
+    }
+
+    @Override
+    public boolean canHandle(final AnalysedComponent analysedComponent) {
+        return mutable.toString().equals(analysedComponent.typeNameWithoutAnnotations().toString());
+    }
+
+    @Override
+    public TypeName extractKeyType(final AnalysedComponent analysedComponent) {
+        return key;
+    }
+
+    @Override
+    public TypeName extractValueType(final AnalysedComponent analysedComponent) {
+        return value;
+    }
+
+    @Override
+    public void addNullableAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+            mutable.annotated(CommonsConstants.NULLABLE_ANNOTATION),
+            component.name(),
+            Modifier.PRIVATE
+        ).build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeNullableAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(mutable.annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .beginControlFlow("if (this.$L != null)", component.name())
+                .addStatement("return this.$L", component.name())
+                .endControlFlow()
+                .addStatement("return null");
+    }
+
+    @Override
+    public void writeNullableAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        final TypeName param = mapParent.annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final String name = component.name();
+        methodBuilder.addParameter(
+            ParameterSpec.builder(param, name)
+                .addJavadoc("Replacement value")
+                .build()
+        );
+        if (nullReplacesNotNull) {
+            methodBuilder.beginControlFlow("if ($L == null)", name)
+                    .addStatement("this.$L = null", name)
+                .nextControlFlow("else")
+                    .addStatement("this.$L = $T.mutable.ofAll($L)", name, factory, name)
+                .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                .addStatement("this.$L = $T.mutable.ofAll($L)", name, factory, name)
+                .endControlFlow();
+        }
+    }
+
+    @Override
+    public void writeNullableAutoAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType, "key")
+                .addJavadoc("The key to add to the map")
+                .build();
+        final ParameterSpec value = ParameterSpec.builder(valueType, "value")
+                .addJavadoc("The value to add to the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addParameter(value)
+                .beginControlFlow("if (this.$L == null)", name)
+                .addStatement("this.$L = $T.mutable.empty()", name, factory)
+                .endControlFlow()
+                .addStatement("this.$L.put(key, value)", name);
+    }
+
+    @Override
+    public void writeNullableAutoRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType, "key")
+                .addJavadoc("The key to remove from the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .beginControlFlow("if (this.$L != null)", name)
+                .addStatement("this.$L.remove(key)", name)
+                .endControlFlow();
+    }
+
+    @Override
+    public void addNullableImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        addNullableAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(mutable.annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .beginControlFlow("if (this.$L != null)", component.name())
+                .addStatement("return $T.mutable.ofAll(this.$L)", factory, component.name())
+                .endControlFlow()
+                .addStatement("return null");
+    }
+
+    @Override
+    public void writeNullableImmutableSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeNullableAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeNullableImmutableAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNullableAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        writeNullableAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void addNonNullAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+                mutable.annotated(CommonsConstants.NON_NULL_ANNOTATION),
+                component.name(),
+                Modifier.PRIVATE,
+                Modifier.FINAL
+        )
+                .initializer("$T.mutable.empty()", factory)
+                .build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeNonNullAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(mutable.annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .addStatement("return this.$L", component.name());
+    }
+
+    @Override
+    public void writeNonNullAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        final String name = component.name();
+        final TypeName param = mapParent.annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        methodBuilder.addParameter(
+                ParameterSpec.builder(param, name)
+                        .addJavadoc("Replacement value")
+                        .build()
+        );
+        methodBuilder.beginControlFlow("if ($L != null)", name)
+                .addStatement("this.$L.clear()", name)
+                .addStatement("this.$L.putAll($L)", name, name)
+                .endControlFlow();
+    }
+
+    @Override
+    public void writeNonNullAutoAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType, "key")
+                .addJavadoc("The key to add to the map")
+                .build();
+        final ParameterSpec value = ParameterSpec.builder(valueType, "value")
+                .addJavadoc("The value to add to the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addParameter(value)
+                .addStatement("this.$L.put(key, value)", name);
+    }
+
+    @Override
+    public void writeNonNullAutoRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType, "key")
+                .addJavadoc("The key to remove from the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addStatement("this.$L.remove(key)", name);
+    }
+
+    @Override
+    public void addNonNullImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        addNonNullAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.returns(mutable.annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .addStatement("return $T.mutable.ofAll(this.$L)", factory, component.name());
+    }
+
+    @Override
+    public void writeNonNullImmutableSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeNonNullAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeNonNullImmutableAddSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNonNullAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableRemoveSingle(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType) {
+        writeNonNullAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void writeMergerMethod(final TypeName keyType, final TypeName valueType, final Builder methodBuilder) {
+        final TypeName paramTypeName = mutable.annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final ParameterSpec paramA = ParameterSpec.builder(paramTypeName, "elA", Modifier.FINAL)
+                .addJavadoc("The preferred input")
+                .build();
+
+        final ParameterSpec paramB = ParameterSpec.builder(paramTypeName, "elB", Modifier.FINAL)
+                .addJavadoc("The non-preferred input")
+                .build();
+        methodBuilder.addParameter(paramA)
+                .addParameter(paramB)
+                .returns(paramTypeName)
+                .addJavadoc("Merger for fields of class {@link $T}", paramTypeName)
+                .beginControlFlow("if ($T.isNull(elA) || elA.isEmpty())", Constants.Names.OBJECTS)
+                .addStatement("return elB")
+                .nextControlFlow("else if ($T.isNull(elB) || elB.isEmpty())", Constants.Names.OBJECTS)
+                .addStatement("return elA")
+                .endControlFlow()
+                .addComment("It isn't documented, but the implementation of `withAllKeyValues` _modifies_ the current collection, preferring")
+                .addComment("  the passed-in value over the calling one, so we call 'from' the non-preferred")
+                .addStatement("return $T.mutable.ofAll(elB).withAllKeyValues(elA.keyValuesView())", factory);
+    }
+
+    @Override
+    public void writeDifferMethod(final TypeName keyType, final TypeName valueType, final Builder methodBuilder, final ClassName collectionResultRecord) {
+        final TypeName paramTypeName = mutable.annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final TypeName setKey = immutableKeySet;
+        methodBuilder.addParameter(ParameterSpec.builder(paramTypeName, "original", Modifier.FINAL).build())
+                .addParameter(ParameterSpec.builder(paramTypeName, "updated", Modifier.FINAL).build())
+                .returns(collectionResultRecord)
+                .addStatement(
+                        "final $T nUpdated = $T.requireNonNullElseGet(updated, () -> $T.mutable.empty())",
+                        paramTypeName.withoutAnnotations(),
+                        Constants.Names.OBJECTS,
+                        factory
+                )
+                .addStatement(
+                        "final $T nOriginal = $T.requireNonNullElseGet(original, () -> $T.mutable.empty())",
+                        paramTypeName.withoutAnnotations(),
+                        Constants.Names.OBJECTS,
+                        factory
+                )
+                .addStatement(
+                        "final $T addedKeys = $T.immutable.ofAll(nUpdated.keysView().reject(nOriginal::containsKey))",
+                        setKey, immutableKeySetFactory
+                )
+                .addStatement(
+                        "final $T removedKeys = $T.immutable.ofAll(nOriginal.keysView().reject(nUpdated::containsKey))",
+                        setKey, immutableKeySetFactory
+                )
+                .addStatement(
+                        "final $T commonKeys = $T.immutable.ofAll(nOriginal.keysView().select(nUpdated::containsKey))",
+                        setKey, immutableKeySetFactory
+                )
+                .addStatement(
+                        "final $T keysWithDifferentValues = commonKeys.reject(k -> Objects.equals(nOriginal.get(k), nUpdated.get(k)))",
+                        setKey
+                )
+                .addStatement(
+                        "final $T keysWithSameValues = commonKeys.newWithoutAll(keysWithDifferentValues)",
+                        setKey
+                )
+                .addStatement(
+                        // Constructor is added, different, same, removed
+                        "return new $T(addedKeys, keysWithDifferentValues, keysWithSameValues, removedKeys)",
+                        collectionResultRecord
+                );
+    }
+
+    @Override
+    public void addDiffRecordComponents(final TypeName keyType, final TypeName valueType, final ToBeBuiltRecord recordBuilder) {
+        final TypeName setKey = immutableKeySet.annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        recordBuilder.addParameterSpec(
+                        ParameterSpec.builder(setKey, "addedKeys")
+                                .addJavadoc("The keys that have been added")
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "keysWithDifferentValues")
+                                .addJavadoc("The keys that exist in both maps, but that have different values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "keysWithSameValues")
+                                .addJavadoc("The keys that exist in both maps and that have the same values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "removedKeys")
+                                .addJavadoc("The keys that have been removed")
+                                .build()
+                );
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutablePrimitiveMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/eclipse/MutablePrimitiveMapHandler.java
@@ -15,6 +15,10 @@ import io.micronaut.sourcegen.javapoet.TypeName;
 import javax.lang.model.element.Modifier;
 
 public final class MutablePrimitiveMapHandler implements EclipseMapHandler {
+    /*
+    A reminder that the explicit type the user has entered is "MutableMap" - so we *must* return mutable variants
+        in our "immutable" methods
+     */
     private static final String factoryPackage = "org.eclipse.collections.api.factory.primitive";
     private static final String containerPackage = "org.eclipse.collections.api.map.primitive";
     private static final String setPackage = "org.eclipse.collections.api.set.primitive";
@@ -170,23 +174,30 @@ public final class MutablePrimitiveMapHandler implements EclipseMapHandler {
 
     @Override
     public void writeNonNullAutoGetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
-        methodBuilder.returns(mutable.annotated(CommonsConstants.NULLABLE_ANNOTATION))
+        methodBuilder.returns(mutable.annotated(CommonsConstants.NON_NULL_ANNOTATION))
                 .addStatement("return this.$L", component.name());
     }
 
     @Override
     public void writeNonNullAutoSetter(final AnalysedComponent component, final Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
         final String name = component.name();
-        final TypeName param = mapParent.annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        final TypeName param = mapParent.annotated(CommonsConstants.NULLABLE_ANNOTATION);
         methodBuilder.addParameter(
                 ParameterSpec.builder(param, name)
                         .addJavadoc("Replacement value")
                         .build()
         );
-        methodBuilder.beginControlFlow("if ($L != null)", name)
-                .addStatement("this.$L.clear()", name)
-                .addStatement("this.$L.putAll($L)", name, name)
-                .endControlFlow();
+        if (nullReplacesNotNull) {
+            methodBuilder.addStatement("this.$L.clear()", name)
+                    .beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.clear()", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        }
     }
 
     @Override
@@ -295,8 +306,8 @@ public final class MutablePrimitiveMapHandler implements EclipseMapHandler {
                         setKey, immutableKeySetFactory
                 )
                 .addStatement(
-                        "final $T keysWithDifferentValues = commonKeys.reject(k -> Objects.equals(nOriginal.get(k), nUpdated.get(k)))",
-                        setKey
+                        "final $T keysWithDifferentValues = commonKeys.reject(k -> $T.equals(nOriginal.get(k), nUpdated.get(k)))",
+                        setKey, CommonsConstants.Names.OBJECTS
                 )
                 .addStatement(
                         "final $T keysWithSameValues = commonKeys.newWithoutAll(keysWithDifferentValues)",

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/hppc/HppcMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/hppc/HppcMapHandler.java
@@ -1,0 +1,9 @@
+package io.github.cbarlin.aru.impl.types.maps.hppc;
+
+import io.github.cbarlin.aru.impl.types.maps.MapHandler;
+
+/**
+ * Marker interface for handlers for HPPC maps
+ */
+public interface HppcMapHandler extends MapHandler {
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapEnumHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapEnumHandler.java
@@ -1,0 +1,231 @@
+package io.github.cbarlin.aru.impl.types.maps.java;
+
+import io.avaje.inject.Component;
+import io.github.cbarlin.aru.core.CommonsConstants;
+import io.github.cbarlin.aru.core.OptionalClassDetector;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.wiring.GlobalScope;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.FieldSpec;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+import javax.lang.model.element.Modifier;
+
+import static io.github.cbarlin.aru.core.CommonsConstants.Names.OBJECTS;
+
+@Component
+@GlobalScope
+public final class JustMapEnumHandler extends JustMapNonEnumHandler {
+
+    @Override
+    public boolean canHandle(final AnalysedComponent analysedComponent) {
+        return analysedComponent.typeNameWithoutAnnotations() instanceof final ParameterizedTypeName ptn &&
+            ptn.rawType.withoutAnnotations().equals(Constants.Names.MAP) &&
+            ptn.typeArguments.size() == 2 &&
+            OptionalClassDetector.checkSameOrSubType(
+                    ptn.typeArguments.getFirst(),
+                    Constants.Names.ENUM
+            );
+    }
+
+    @Override
+    public void writeNullableImmutableGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        methodBuilder.returns(ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .beginControlFlow("if (this.$L != null)", name)
+                .addStatement("return $T.unmodifiableMap(new $T<>(this.$L))", Constants.Names.COLLECTIONS, Constants.Names.ENUM_MAP, name)
+                .endControlFlow()
+                .addStatement("return null");
+    }
+
+    @Override
+    public void writeNonNullImmutableGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        methodBuilder.returns(ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION))
+                .addStatement("return $T.unmodifiableMap(new $T<>(this.$L))", Constants.Names.COLLECTIONS, Constants.Names.ENUM_MAP, name);
+    }
+
+    @Override
+    public void addNullableImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+                ParameterizedTypeName.get(Constants.Names.ENUM_MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION),
+                component.name(),
+                Modifier.PRIVATE
+        ).build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeNullableImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        final String name = component.name();
+        final ParameterSpec param = ParameterSpec.builder(
+                        ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION),
+                        name
+                )
+                .addJavadoc("Replacement value")
+                .build();
+        methodBuilder.addParameter(param);
+        methodBuilder.beginControlFlow("if (this.$L == null)", name)
+                .addStatement("this.$L = new $T<>($T.class)", name, Constants.Names.ENUM_MAP, keyType)
+                .endControlFlow();
+        if (nullReplacesNotNull) {
+            methodBuilder.addStatement("this.$L.clear()", name)
+                    .beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.clear()", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        }
+    }
+
+    @Override
+    public void writeNullableImmutableAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to add to the map")
+                .build();
+        final ParameterSpec value = ParameterSpec.builder(valueType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "value")
+                .addJavadoc("The value to add to the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addParameter(value)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for addition cannot be null")
+                .addStatement("$T.requireNonNull(value, $S)", Constants.Names.OBJECTS, "Supplied value to be added cannot be null")
+                .beginControlFlow("if (this.$L == null)", name)
+                .addStatement("this.$L = new $T<>($T.class)", name, Constants.Names.ENUM_MAP, keyType)
+                .endControlFlow()
+                .addStatement("this.$L.put(key, value)", name);
+    }
+
+    @Override
+    public void addNonNullImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+                ParameterizedTypeName.get(Constants.Names.ENUM_MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION),
+                component.name(),
+                Modifier.PRIVATE
+        )
+                .initializer("new $T<>($T.class)", Constants.Names.ENUM_MAP, keyType)
+                .build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeMergerMethod(final TypeName keyType, final TypeName valueType, final MethodSpec.Builder methodBuilder) {
+        final TypeName paramTypeName = ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final ParameterSpec paramA = ParameterSpec.builder(paramTypeName, "elA", Modifier.FINAL)
+                .addJavadoc("The preferred input")
+                .build();
+
+        final ParameterSpec paramB = ParameterSpec.builder(paramTypeName, "elB", Modifier.FINAL)
+                .addJavadoc("The non-preferred input")
+                .build();
+        methodBuilder.addParameter(paramA)
+                .addParameter(paramB)
+                .returns(paramTypeName)
+                .addJavadoc("Merger for fields of class {@link $T}", paramTypeName)
+                .beginControlFlow("if ($T.isNull(elA) || elA.isEmpty())", OBJECTS)
+                .addStatement("return elB")
+                .nextControlFlow("else if ($T.isNull(elB) || elB.isEmpty())", OBJECTS)
+                .addStatement("return elA")
+                .endControlFlow()
+                .addStatement(
+                    "final $T<$T, $T> combined = new $T<>($T.class)",
+                    Constants.Names.MAP,
+                    keyType,
+                    valueType,
+                    Constants.Names.ENUM_MAP,
+                    keyType
+                )
+                // putAll overrides existing entries, so put all the non-preferred ones first
+                .addStatement("combined.putAll(elB)")
+                .addStatement("combined.putAll(elA)")
+                // Since this goes via the builder, that will handle things like immutability
+                .addStatement("return combined");
+    }
+
+    @Override
+    public void writeDifferMethod(final TypeName keyType, final TypeName valueType, final MethodSpec.Builder methodBuilder, final ClassName collectionResultRecord) {
+        final TypeName paramTypeName = ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final TypeName setKey = ParameterizedTypeName.get(Constants.Names.SET, keyType).annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        methodBuilder.addParameter(ParameterSpec.builder(paramTypeName, "original", Modifier.FINAL).build())
+                .addParameter(ParameterSpec.builder(paramTypeName, "updated", Modifier.FINAL).build())
+                .returns(collectionResultRecord)
+                .addStatement(
+                        "final $T nUpdated = $T.requireNonNullElseGet(updated, $T::emptyMap)",
+                        paramTypeName,
+                        Constants.Names.OBJECTS,
+                        Constants.Names.COLLECTIONS
+                )
+                .addStatement(
+                        "final $T nOriginal = $T.requireNonNullElseGet(original, $T::emptyMap)",
+                        paramTypeName,
+                        Constants.Names.OBJECTS,
+                        Constants.Names.COLLECTIONS
+                )
+                .addStatement(
+                        "final $T addedKeys = $T.noneOf($T.class)",
+                        setKey,
+                        Constants.Names.ENUM_SET,
+                        keyType
+                )
+                .addStatement(
+                        "final $T removedKeys = $T.noneOf($T.class)",
+                        setKey,
+                        Constants.Names.ENUM_SET,
+                        keyType
+                )
+                .addStatement(
+                        "final $T commonKeys = $T.noneOf($T.class)",
+                        setKey,
+                        Constants.Names.ENUM_SET,
+                        keyType
+                )
+                .addStatement(
+                        "final $T keysWithDifferentValues = $T.noneOf($T.class)",
+                        setKey,
+                        Constants.Names.ENUM_SET,
+                        keyType
+                )
+                .addStatement(
+                        "final $T keysWithSameValues = $T.noneOf($T.class)",
+                        setKey,
+                        Constants.Names.ENUM_SET,
+                        keyType
+                )
+                .addStatement(
+                        "nUpdated.keySet().stream().filter($T.not(nOriginal::containsKey)).forEach(addedKeys::add)",
+                        Constants.Names.PREDICATE
+                )
+                .addStatement(
+                        "nOriginal.keySet().stream().filter($T.not(nUpdated::containsKey)).forEach(removedKeys::add)",
+                        Constants.Names.PREDICATE
+                )
+                .addStatement(
+                        "nOriginal.keySet().stream().filter(nUpdated::containsKey).forEach(commonKeys::add)"
+                )
+                .beginControlFlow("for (final $T key : commonKeys)", keyType)
+                .beginControlFlow("if ($T.equals(nOriginal.get(key), nUpdated.get(key)))", Constants.Names.OBJECTS)
+                .addStatement("keysWithSameValues.add(key)")
+                .nextControlFlow("else")
+                .addStatement("keysWithDifferentValues.add(key)")
+                .endControlFlow()
+                .endControlFlow()
+                .addStatement(
+                        // Constructor is added, removed, different, same
+                        "return new $T($T.unmodifiableSet(addedKeys), $T.unmodifiableSet(removedKeys), $T.unmodifiableSet(keysWithDifferentValues), $T.unmodifiableSet(keysWithSameValues))",
+                        collectionResultRecord,
+                        Constants.Names.COLLECTIONS,
+                        Constants.Names.COLLECTIONS,
+                        Constants.Names.COLLECTIONS,
+                        Constants.Names.COLLECTIONS
+                );
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapEnumHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapEnumHandler.java
@@ -219,8 +219,8 @@ public final class JustMapEnumHandler extends JustMapNonEnumHandler {
                 .endControlFlow()
                 .endControlFlow()
                 .addStatement(
-                        // Constructor is added, removed, different, same
-                        "return new $T($T.unmodifiableSet(addedKeys), $T.unmodifiableSet(removedKeys), $T.unmodifiableSet(keysWithDifferentValues), $T.unmodifiableSet(keysWithSameValues))",
+                        // Constructor is added, different, same, removed
+                        "return new $T($T.unmodifiableSet(addedKeys), $T.unmodifiableSet(keysWithDifferentValues), $T.unmodifiableSet(keysWithSameValues), $T.unmodifiableSet(removedKeys))",
                         collectionResultRecord,
                         Constants.Names.COLLECTIONS,
                         Constants.Names.COLLECTIONS,

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapEnumHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapEnumHandler.java
@@ -70,17 +70,20 @@ public final class JustMapEnumHandler extends JustMapNonEnumHandler {
                 .addJavadoc("Replacement value")
                 .build();
         methodBuilder.addParameter(param);
-        methodBuilder.beginControlFlow("if (this.$L == null)", name)
-                .addStatement("this.$L = new $T<>($T.class)", name, Constants.Names.ENUM_MAP, keyType)
-                .endControlFlow();
         if (nullReplacesNotNull) {
-            methodBuilder.addStatement("this.$L.clear()", name)
-                    .beginControlFlow("if ($L != null)", name)
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L = new $T<>($T.class)", name, Constants.Names.ENUM_MAP, keyType)
                     .addStatement("this.$L.putAll($L)", name, name)
+                    .nextControlFlow("else")
+                    .addStatement("this.$L = null", name)
                     .endControlFlow();
         } else {
             methodBuilder.beginControlFlow("if ($L != null)", name)
+                    .beginControlFlow("if (this.$L == null)", name)
+                    .addStatement("this.$L = new $T<>($T.class)", name, Constants.Names.ENUM_MAP, keyType)
+                    .nextControlFlow("else")
                     .addStatement("this.$L.clear()", name)
+                    .endControlFlow()
                     .addStatement("this.$L.putAll($L)", name, name)
                     .endControlFlow();
         }
@@ -110,7 +113,8 @@ public final class JustMapEnumHandler extends JustMapNonEnumHandler {
         final FieldSpec fieldSpec = FieldSpec.builder(
                 ParameterizedTypeName.get(Constants.Names.ENUM_MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION),
                 component.name(),
-                Modifier.PRIVATE
+                Modifier.PRIVATE,
+                Modifier.FINAL
         )
                 .initializer("new $T<>($T.class)", Constants.Names.ENUM_MAP, keyType)
                 .build();

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapNonEnumHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapNonEnumHandler.java
@@ -67,8 +67,18 @@ public class JustMapNonEnumHandler implements MapHandler {
                 )
                 .addJavadoc("Replacement value")
                 .build();
-        methodBuilder.addParameter(param)
-                .addStatement("this.$L = $L", name, name);
+        methodBuilder.addParameter(param);
+        if (nullReplacesNotNull) {
+            methodBuilder.beginControlFlow("if ($L == null)", name)
+                    .addStatement("this.$L = null", name)
+                    .nextControlFlow("else")
+                    .addStatement("this.$L = new $T<>($L)", name, Constants.Names.HASH_MAP, name)
+                    .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L = new $T<>($L)", name, Constants.Names.HASH_MAP, name)
+                    .endControlFlow();
+        }
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapNonEnumHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapNonEnumHandler.java
@@ -146,9 +146,10 @@ public class JustMapNonEnumHandler implements MapHandler {
     @Override
     public void addNonNullAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
         final FieldSpec fieldSpec = FieldSpec.builder(
-                        ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION),
-                        component.name(),
-                        Modifier.PRIVATE
+                    ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION),
+                    component.name(),
+                    Modifier.PRIVATE,
+                    Modifier.FINAL
                 )
                 .initializer("new $T<>()", Constants.Names.HASH_MAP)
                 .build();
@@ -325,8 +326,8 @@ public class JustMapNonEnumHandler implements MapHandler {
                 .endControlFlow()
                 .endControlFlow()
                 .addStatement(
-                        // Constructor is added, removed, different, same
-                        "return new $T(addedKeys, removedKeys, $T.unmodifiableSet(keysWithDifferentValues), $T.unmodifiableSet(keysWithSameValues))",
+                        // Constructor is added, different, same, removed
+                        "return new $T(addedKeys, $T.unmodifiableSet(keysWithDifferentValues), $T.unmodifiableSet(keysWithSameValues), removedKeys)",
                         collectionResultRecord,
                         Constants.Names.COLLECTIONS,
                         Constants.Names.COLLECTIONS
@@ -342,11 +343,6 @@ public class JustMapNonEnumHandler implements MapHandler {
                                 .build()
                 )
                 .addParameterSpec(
-                        ParameterSpec.builder(setKey, "removedKeys")
-                                .addJavadoc("The keys that have been removed")
-                                .build()
-                )
-                .addParameterSpec(
                         ParameterSpec.builder(setKey, "keysWithDifferentValues")
                                 .addJavadoc("The keys that exist in both maps, but that have different values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
                                 .build()
@@ -354,6 +350,11 @@ public class JustMapNonEnumHandler implements MapHandler {
                 .addParameterSpec(
                         ParameterSpec.builder(setKey, "keysWithSameValues")
                                 .addJavadoc("The keys that exist in both maps and that have the same values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "removedKeys")
+                                .addJavadoc("The keys that have been removed")
                                 .build()
                 );
     }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapNonEnumHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapNonEnumHandler.java
@@ -308,12 +308,12 @@ public class JustMapNonEnumHandler implements MapHandler {
                         CommonsConstants.Names.COLLECTORS
                 )
                 .addStatement(
-                        "final $T keysWithDifferentValues = new $T<>()",
+                        "final $T keysWithDifferentValues = $T.newHashSet(commonKeys.size())",
                         setKey,
                         CommonsConstants.Names.HASH_SET
                 )
                 .addStatement(
-                        "final $T keysWithSameValues = new $T<>()",
+                        "final $T keysWithSameValues = $T.newHashSet(commonKeys.size())",
                         setKey,
                         CommonsConstants.Names.HASH_SET
                 )

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapNonEnumHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/java/JustMapNonEnumHandler.java
@@ -1,0 +1,350 @@
+package io.github.cbarlin.aru.impl.types.maps.java;
+
+import io.avaje.inject.Component;
+import io.github.cbarlin.aru.core.CommonsConstants;
+import io.github.cbarlin.aru.core.OptionalClassDetector;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.impl.Constants;
+import io.github.cbarlin.aru.impl.types.maps.MapHandler;
+import io.github.cbarlin.aru.impl.wiring.GlobalScope;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.FieldSpec;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.ParameterSpec;
+import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
+import io.micronaut.sourcegen.javapoet.TypeName;
+import javax.lang.model.element.Modifier;
+
+@Component
+@GlobalScope
+public class JustMapNonEnumHandler implements MapHandler {
+
+    @Override
+    public boolean canHandle(final AnalysedComponent analysedComponent) {
+        return analysedComponent.typeNameWithoutAnnotations() instanceof final ParameterizedTypeName ptn &&
+            ptn.rawType.withoutAnnotations().equals(Constants.Names.MAP) &&
+            ptn.typeArguments.size() == 2 &&
+            !OptionalClassDetector.checkSameOrSubType(
+                    ptn.typeArguments.getFirst(),
+                    Constants.Names.ENUM
+            );
+    }
+
+    @Override
+    public TypeName extractKeyType(final AnalysedComponent analysedComponent) {
+        return ((ParameterizedTypeName) analysedComponent.typeName()).typeArguments.getFirst().withoutAnnotations();
+    }
+
+    @Override
+    public TypeName extractValueType(final AnalysedComponent analysedComponent) {
+        return ((ParameterizedTypeName) analysedComponent.typeName()).typeArguments.getLast().withoutAnnotations();
+    }
+
+    @Override
+    public void addNullableAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+                ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION),
+                component.name(),
+                Modifier.PRIVATE
+        ).build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeNullableAutoGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.addStatement("return this.$L", component.name())
+                .returns(ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION));
+    }
+
+    @Override
+    public void writeNullableAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        final String name = component.name();
+        final ParameterSpec param = ParameterSpec.builder(
+                        ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION),
+                        name
+                )
+                .addJavadoc("Replacement value")
+                .build();
+        methodBuilder.addParameter(param)
+                .addStatement("this.$L = $L", name, name);
+    }
+
+    @Override
+    public void writeNullableAutoAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to add to the map")
+                .build();
+        final ParameterSpec value = ParameterSpec.builder(valueType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "value")
+                .addJavadoc("The value to add to the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addParameter(value)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for addition cannot be null")
+                .addStatement("$T.requireNonNull(value, $S)", Constants.Names.OBJECTS, "Supplied value to be added cannot be null")
+                .beginControlFlow("if (this.$L == null)", name)
+                .addStatement("this.$L = new $T<>()", name, Constants.Names.HASH_MAP)
+                .endControlFlow()
+                .addStatement("this.$L.put(key, value)", name);
+    }
+
+    @Override
+    public void writeNullableAutoRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to remove from the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for removal cannot be null")
+                .beginControlFlow("if (this.$L != null)", name)
+                .addStatement("this.$L.remove(key)", name)
+                .endControlFlow();
+    }
+
+    @Override
+    public void addNullableImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        addNullableAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        methodBuilder.returns(ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION))
+                .beginControlFlow("if (this.$L != null)", name)
+                .addStatement("return $T.copyOf(this.$L)", Constants.Names.MAP, name)
+                .endControlFlow()
+                .addStatement("return null");
+    }
+
+    @Override
+    public void writeNullableImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeNullableAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeNullableImmutableAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNullableAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNullableImmutableRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType) {
+        writeNullableAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void addNonNullAutoField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        final FieldSpec fieldSpec = FieldSpec.builder(
+                        ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION),
+                        component.name(),
+                        Modifier.PRIVATE
+                )
+                .initializer("new $T<>()", Constants.Names.HASH_MAP)
+                .build();
+        addFieldTo.addField(fieldSpec);
+    }
+
+    @Override
+    public void writeNonNullAutoGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        methodBuilder.addStatement("return this.$L", component.name())
+                .returns(ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION));
+    }
+
+    @Override
+    public void writeNonNullAutoSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        final String name = component.name();
+        final ParameterSpec param = ParameterSpec.builder(
+                        ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION),
+                        name
+                )
+                .addJavadoc("Replacement value")
+                .build();
+        methodBuilder.addParameter(param);
+        if (nullReplacesNotNull) {
+            methodBuilder.addStatement("this.$L.clear()", name)
+                    .beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        } else {
+            methodBuilder.beginControlFlow("if ($L != null)", name)
+                    .addStatement("this.$L.clear()", name)
+                    .addStatement("this.$L.putAll($L)", name, name)
+                    .endControlFlow();
+        }
+    }
+
+    @Override
+    public void writeNonNullAutoAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to add to the map")
+                .build();
+        final ParameterSpec value = ParameterSpec.builder(valueType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "value")
+                .addJavadoc("The value to add to the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addParameter(value)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for addition cannot be null")
+                .addStatement("$T.requireNonNull(value, $S)", Constants.Names.OBJECTS, "Supplied value to be added cannot be null")
+                .addStatement("this.$L.put(key, value)", name);
+    }
+
+    @Override
+    public void writeNonNullAutoRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType) {
+        final String name = component.name();
+        final ParameterSpec key = ParameterSpec.builder(keyType.annotated(CommonsConstants.NON_NULL_ANNOTATION), "key")
+                .addJavadoc("The key to remove from the map")
+                .build();
+        methodBuilder.addParameter(key)
+                .addStatement("$T.requireNonNull(key, $S)", Constants.Names.OBJECTS, "Supplied key for removal cannot be null")
+                .addStatement("this.$L.remove(key)", name);
+    }
+
+    @Override
+    public void addNonNullImmutableField(final AnalysedComponent component, final ToBeBuilt addFieldTo, final TypeName keyType, final TypeName valueType) {
+        addNonNullAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableGetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        final String name = component.name();
+        methodBuilder.returns(ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NON_NULL_ANNOTATION))
+                .addStatement("return $T.copyOf(this.$L)", Constants.Names.MAP, name);
+    }
+
+    @Override
+    public void writeNonNullImmutableSetter(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType, final boolean nullReplacesNotNull) {
+        writeNonNullAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeNonNullImmutableAddSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType, final TypeName valueType) {
+        writeNonNullAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeNonNullImmutableRemoveSingle(final AnalysedComponent component, final MethodSpec.Builder methodBuilder, final TypeName keyType) {
+        writeNonNullAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void writeMergerMethod(final TypeName keyType, final TypeName valueType, final MethodSpec.Builder methodBuilder) {
+        final TypeName paramTypeName = ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final ParameterSpec paramA = ParameterSpec.builder(paramTypeName, "elA", Modifier.FINAL)
+                .addJavadoc("The preferred input")
+                .build();
+
+        final ParameterSpec paramB = ParameterSpec.builder(paramTypeName, "elB", Modifier.FINAL)
+                .addJavadoc("The non-preferred input")
+                .build();
+        methodBuilder.addParameter(paramA)
+                .addParameter(paramB)
+                .returns(paramTypeName)
+                .addJavadoc("Merger for fields of class {@link $T}", paramTypeName)
+                .beginControlFlow("if ($T.isNull(elA) || elA.isEmpty())", Constants.Names.OBJECTS)
+                .addStatement("return elB")
+                .nextControlFlow("else if ($T.isNull(elB) || elB.isEmpty())", Constants.Names.OBJECTS)
+                .addStatement("return elA")
+                .endControlFlow()
+                .addStatement(
+                    "final $T<$T, $T> combined = new $T<>()",
+                    Constants.Names.MAP,
+                    keyType,
+                    valueType,
+                    Constants.Names.HASH_MAP
+                )
+                // putAll overrides existing entries, so put all the non-preferred ones first
+                .addStatement("combined.putAll(elB)")
+                .addStatement("combined.putAll(elA)")
+                // Since this goes via the builder, that will handle things like immutability
+                .addStatement("return combined");
+    }
+
+    @Override
+    public void writeDifferMethod(final TypeName keyType, final TypeName valueType, final MethodSpec.Builder methodBuilder, final ClassName collectionResultRecord) {
+        final TypeName paramTypeName = ParameterizedTypeName.get(Constants.Names.MAP, keyType, valueType).annotated(CommonsConstants.NULLABLE_ANNOTATION);
+        final TypeName setKey = ParameterizedTypeName.get(Constants.Names.SET, keyType).annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        methodBuilder.addParameter(ParameterSpec.builder(paramTypeName, "original", Modifier.FINAL).build())
+                .addParameter(ParameterSpec.builder(paramTypeName, "updated", Modifier.FINAL).build())
+                .returns(collectionResultRecord)
+                .addStatement(
+                        "final $T nUpdated = $T.requireNonNullElseGet(updated, $T::emptyMap)",
+                        paramTypeName,
+                        Constants.Names.OBJECTS,
+                        Constants.Names.COLLECTIONS
+                )
+                .addStatement(
+                        "final $T nOriginal = $T.requireNonNullElseGet(original, $T::emptyMap)",
+                        paramTypeName,
+                        Constants.Names.OBJECTS,
+                        Constants.Names.COLLECTIONS
+                )
+                .addStatement(
+                        "final $T addedKeys = nUpdated.keySet().stream().filter($T.not(nOriginal::containsKey)).collect($T.toUnmodifiableSet())",
+                        setKey,
+                        Constants.Names.PREDICATE,
+                        CommonsConstants.Names.COLLECTORS
+                )
+                .addStatement(
+                        "final $T removedKeys = nOriginal.keySet().stream().filter($T.not(nUpdated::containsKey)).collect($T.toUnmodifiableSet())",
+                        setKey,
+                        Constants.Names.PREDICATE,
+                        CommonsConstants.Names.COLLECTORS
+                )
+                .addStatement(
+                        "final $T commonKeys = nOriginal.keySet().stream().filter(nUpdated::containsKey).collect($T.toUnmodifiableSet())",
+                        setKey,
+                        CommonsConstants.Names.COLLECTORS
+                )
+                .addStatement(
+                        "final $T keysWithDifferentValues = new $T<>()",
+                        setKey,
+                        CommonsConstants.Names.HASH_SET
+                )
+                .addStatement(
+                        "final $T keysWithSameValues = new $T<>()",
+                        setKey,
+                        CommonsConstants.Names.HASH_SET
+                )
+                .beginControlFlow("for (final $T key : commonKeys)", keyType)
+                .beginControlFlow("if ($T.equals(nOriginal.get(key), nUpdated.get(key)))", Constants.Names.OBJECTS)
+                .addStatement("keysWithSameValues.add(key)")
+                .nextControlFlow("else")
+                .addStatement("keysWithDifferentValues.add(key)")
+                .endControlFlow()
+                .endControlFlow()
+                .addStatement(
+                        // Constructor is added, removed, different, same
+                        "return new $T(addedKeys, removedKeys, $T.unmodifiableSet(keysWithDifferentValues), $T.unmodifiableSet(keysWithSameValues))",
+                        collectionResultRecord,
+                        Constants.Names.COLLECTIONS,
+                        Constants.Names.COLLECTIONS
+                );
+    }
+
+    @Override
+    public void addDiffRecordComponents(final TypeName keyType, final TypeName valueType, final ToBeBuiltRecord recordBuilder) {
+        final TypeName setKey = ParameterizedTypeName.get(Constants.Names.SET, keyType).annotated(CommonsConstants.NON_NULL_ANNOTATION);
+        recordBuilder.addParameterSpec(
+                        ParameterSpec.builder(setKey, "addedKeys")
+                                .addJavadoc("The keys that have been added")
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "removedKeys")
+                                .addJavadoc("The keys that have been removed")
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "keysWithDifferentValues")
+                                .addJavadoc("The keys that exist in both maps, but that have different values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
+                                .build()
+                )
+                .addParameterSpec(
+                        ParameterSpec.builder(setKey, "keysWithSameValues")
+                                .addJavadoc("The keys that exist in both maps and that have the same values (via {@link $T#equals($T, $T)})", Constants.Names.OBJECTS, Constants.Names.OBJECT, Constants.Names.OBJECT)
+                                .build()
+                );
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NonNullAutoMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NonNullAutoMapHandler.java
@@ -1,0 +1,72 @@
+package io.github.cbarlin.aru.impl.types.maps.wrapper;
+
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.visitors.AruVisitor;
+import io.github.cbarlin.aru.impl.types.maps.MapHandler;
+import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+public record NonNullAutoMapHandler(
+    AnalysedComponent component,
+    TypeName keyType,
+    TypeName valueType,
+    MapHandler handler,
+    boolean nullReplacesNotNull
+) implements MapHandlerHelper {
+    public NonNullAutoMapHandler(
+            final AnalysedComponent component,
+            final MapHandler handler,
+            final boolean nullReplacesNotNull
+    ) {
+        this(component, handler.extractKeyType(component), handler.extractValueType(component), handler, nullReplacesNotNull);
+    }
+
+    @Override
+    public void addField(final ToBeBuilt addFieldTo) {
+        handler.addNonNullAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeGetter(final MethodSpec.Builder methodBuilder) {
+        handler.writeNonNullAutoGetter(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeSetter(final MethodSpec.Builder methodBuilder) {
+        handler.writeNonNullAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeAddSingle(final MethodSpec.Builder methodBuilder) {
+        handler.writeNonNullAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeRemoveSingle(final MethodSpec.Builder methodBuilder) {
+        handler.writeNonNullAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void writeSpecialisedMethods(final ToBeBuilt toBeBuilt, final AruVisitor<?> visitor) {
+        handler.writeNonNullAutoSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType);
+    }
+
+    @Override
+    public void writeMergerMethod(final MethodSpec.Builder methodBuilder) {
+        handler.writeMergerMethod(keyType, valueType, methodBuilder);
+    }
+
+    @Override
+    public void writeDifferMethod(final MethodSpec.Builder methodBuilder, final ClassName collectionResultRecord) {
+        handler.writeDifferMethod(keyType, valueType, methodBuilder, collectionResultRecord);
+    }
+
+    @Override
+    public void addDiffRecordComponents(final ToBeBuiltRecord recordBuilder) {
+        handler.addDiffRecordComponents(keyType, valueType, recordBuilder);
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NonNullAutoMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NonNullAutoMapHandler.java
@@ -52,7 +52,7 @@ public record NonNullAutoMapHandler(
 
     @Override
     public void writeSpecialisedMethods(final ToBeBuilt toBeBuilt, final AruVisitor<?> visitor) {
-        handler.writeNonNullAutoSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType);
+        handler.writeNonNullAutoSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType, nullReplacesNotNull);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NonNullImmutableMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NonNullImmutableMapHandler.java
@@ -1,0 +1,72 @@
+package io.github.cbarlin.aru.impl.types.maps.wrapper;
+
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.visitors.AruVisitor;
+import io.github.cbarlin.aru.impl.types.maps.MapHandler;
+import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+public record NonNullImmutableMapHandler(
+    AnalysedComponent component,
+    TypeName keyType,
+    TypeName valueType,
+    MapHandler handler,
+    boolean nullReplacesNotNull
+) implements MapHandlerHelper {
+    public NonNullImmutableMapHandler(
+            final AnalysedComponent component,
+            final MapHandler handler,
+            final boolean nullReplacesNotNull
+    ) {
+        this(component, handler.extractKeyType(component), handler.extractValueType(component), handler, nullReplacesNotNull);
+    }
+
+    @Override
+    public void addField(final ToBeBuilt addFieldTo) {
+        handler.addNonNullImmutableField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeGetter(final MethodSpec.Builder methodBuilder) {
+        handler.writeNonNullImmutableGetter(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeSetter(final MethodSpec.Builder methodBuilder) {
+        handler.writeNonNullImmutableSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeAddSingle(final MethodSpec.Builder methodBuilder) {
+        handler.writeNonNullImmutableAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeRemoveSingle(final MethodSpec.Builder methodBuilder) {
+        handler.writeNonNullImmutableRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void writeSpecialisedMethods(final ToBeBuilt toBeBuilt, final AruVisitor<?> visitor) {
+        handler.writeNonNullImmutableSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType);
+    }
+
+    @Override
+    public void writeMergerMethod(final MethodSpec.Builder methodBuilder) {
+        handler.writeMergerMethod(keyType, valueType, methodBuilder);
+    }
+
+    @Override
+    public void writeDifferMethod(final MethodSpec.Builder methodBuilder, final ClassName collectionResultRecord) {
+        handler.writeDifferMethod(keyType, valueType, methodBuilder, collectionResultRecord);
+    }
+
+    @Override
+    public void addDiffRecordComponents(final ToBeBuiltRecord recordBuilder) {
+        handler.addDiffRecordComponents(keyType, valueType, recordBuilder);
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NonNullImmutableMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NonNullImmutableMapHandler.java
@@ -52,7 +52,7 @@ public record NonNullImmutableMapHandler(
 
     @Override
     public void writeSpecialisedMethods(final ToBeBuilt toBeBuilt, final AruVisitor<?> visitor) {
-        handler.writeNonNullImmutableSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType);
+        handler.writeNonNullImmutableSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType, nullReplacesNotNull);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NullableAutoMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NullableAutoMapHandler.java
@@ -52,7 +52,7 @@ public record NullableAutoMapHandler(
 
     @Override
     public void writeSpecialisedMethods(final ToBeBuilt toBeBuilt, final AruVisitor<?> visitor) {
-        handler.writeNullableAutoSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType);
+        handler.writeNullableAutoSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType, nullReplacesNotNull);
     }
 
     @Override

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NullableAutoMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NullableAutoMapHandler.java
@@ -1,0 +1,72 @@
+package io.github.cbarlin.aru.impl.types.maps.wrapper;
+
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.visitors.AruVisitor;
+import io.github.cbarlin.aru.impl.types.maps.MapHandler;
+import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+public record NullableAutoMapHandler(
+    AnalysedComponent component,
+    TypeName keyType,
+    TypeName valueType,
+    MapHandler handler,
+    boolean nullReplacesNotNull
+) implements MapHandlerHelper {
+    public NullableAutoMapHandler(
+            final AnalysedComponent component,
+            final MapHandler handler,
+            final boolean nullReplacesNotNull
+    ) {
+        this(component, handler.extractKeyType(component), handler.extractValueType(component), handler, nullReplacesNotNull);
+    }
+
+    @Override
+    public void addField(final ToBeBuilt addFieldTo) {
+        handler.addNullableAutoField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeGetter(final MethodSpec.Builder methodBuilder) {
+        handler.writeNullableAutoGetter(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeSetter(final MethodSpec.Builder methodBuilder) {
+        handler.writeNullableAutoSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeAddSingle(final MethodSpec.Builder methodBuilder) {
+        handler.writeNullableAutoAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeRemoveSingle(final MethodSpec.Builder methodBuilder) {
+        handler.writeNullableAutoRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void writeSpecialisedMethods(final ToBeBuilt toBeBuilt, final AruVisitor<?> visitor) {
+        handler.writeNullableAutoSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType);
+    }
+
+    @Override
+    public void writeMergerMethod(final MethodSpec.Builder methodBuilder) {
+        handler.writeMergerMethod(keyType, valueType, methodBuilder);
+    }
+
+    @Override
+    public void writeDifferMethod(final MethodSpec.Builder methodBuilder, final ClassName collectionResultRecord) {
+        handler.writeDifferMethod(keyType, valueType, methodBuilder, collectionResultRecord);
+    }
+
+    @Override
+    public void addDiffRecordComponents(final ToBeBuiltRecord recordBuilder) {
+        handler.addDiffRecordComponents(keyType, valueType, recordBuilder);
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NullableImmutableMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NullableImmutableMapHandler.java
@@ -1,0 +1,72 @@
+package io.github.cbarlin.aru.impl.types.maps.wrapper;
+
+import io.github.cbarlin.aru.core.artifacts.ToBeBuilt;
+import io.github.cbarlin.aru.core.artifacts.ToBeBuiltRecord;
+import io.github.cbarlin.aru.core.types.AnalysedComponent;
+import io.github.cbarlin.aru.core.visitors.AruVisitor;
+import io.github.cbarlin.aru.impl.types.maps.MapHandler;
+import io.github.cbarlin.aru.impl.types.maps.MapHandlerHelper;
+import io.micronaut.sourcegen.javapoet.ClassName;
+import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
+
+public record NullableImmutableMapHandler(
+    AnalysedComponent component,
+    TypeName keyType,
+    TypeName valueType,
+    MapHandler handler,
+    boolean nullReplacesNotNull
+) implements MapHandlerHelper {
+    public NullableImmutableMapHandler(
+            final AnalysedComponent component,
+            final MapHandler handler,
+            final boolean nullReplacesNotNull
+    ) {
+        this(component, handler.extractKeyType(component), handler.extractValueType(component), handler, nullReplacesNotNull);
+    }
+
+    @Override
+    public void addField(final ToBeBuilt addFieldTo) {
+        handler.addNullableImmutableField(component, addFieldTo, keyType, valueType);
+    }
+
+    @Override
+    public void writeGetter(final MethodSpec.Builder methodBuilder) {
+        handler.writeNullableImmutableGetter(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeSetter(final MethodSpec.Builder methodBuilder) {
+        handler.writeNullableImmutableSetter(component, methodBuilder, keyType, valueType, nullReplacesNotNull);
+    }
+
+    @Override
+    public void writeAddSingle(final MethodSpec.Builder methodBuilder) {
+        handler.writeNullableImmutableAddSingle(component, methodBuilder, keyType, valueType);
+    }
+
+    @Override
+    public void writeRemoveSingle(final MethodSpec.Builder methodBuilder) {
+        handler.writeNullableImmutableRemoveSingle(component, methodBuilder, keyType);
+    }
+
+    @Override
+    public void writeSpecialisedMethods(final ToBeBuilt toBeBuilt, final AruVisitor<?> visitor) {
+        handler.writeNullableImmutableSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType);
+    }
+
+    @Override
+    public void writeMergerMethod(final MethodSpec.Builder methodBuilder) {
+        handler.writeMergerMethod(keyType, valueType, methodBuilder);
+    }
+
+    @Override
+    public void writeDifferMethod(final MethodSpec.Builder methodBuilder, final ClassName collectionResultRecord) {
+        handler.writeDifferMethod(keyType, valueType, methodBuilder, collectionResultRecord);
+    }
+
+    @Override
+    public void addDiffRecordComponents(final ToBeBuiltRecord recordBuilder) {
+        handler.addDiffRecordComponents(keyType, valueType, recordBuilder);
+    }
+}

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NullableImmutableMapHandler.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/types/maps/wrapper/NullableImmutableMapHandler.java
@@ -52,7 +52,7 @@ public record NullableImmutableMapHandler(
 
     @Override
     public void writeSpecialisedMethods(final ToBeBuilt toBeBuilt, final AruVisitor<?> visitor) {
-        handler.writeNullableImmutableSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType);
+        handler.writeNullableImmutableSpecialisedMethods(component, visitor, toBeBuilt, keyType, valueType, nullReplacesNotNull);
     }
 
     @Override

--- a/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NonNullableAutoMapBag.java
+++ b/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NonNullableAutoMapBag.java
@@ -2,9 +2,7 @@ package io.github.cbarlin.aru.tests.c_odd_types;
 
 import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
 
 @AdvancedRecordUtils(
         builderOptions = @AdvancedRecordUtils.BuilderOptions(

--- a/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NonNullableImmutableMapBag.java
+++ b/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NonNullableImmutableMapBag.java
@@ -9,7 +9,7 @@ import java.util.TreeMap;
 @AdvancedRecordUtils(
         builderOptions = @AdvancedRecordUtils.BuilderOptions(
                 // These should all be the defaults
-                // builtCollectionType = BuiltCollectionType.JAVA_IMMUTABLE,
+                builtCollectionType = AdvancedRecordUtils.BuiltCollectionType.JAVA_IMMUTABLE
                 // buildNullCollectionToEmpty = true
                 // createAdderMethods = true
         ),
@@ -31,8 +31,6 @@ public record NonNullableImmutableMapBag(
     Map<String, String> stringStringMap,
     Map<String, AnEnum> stringAnEnumMap,
     Map<MapKeyRecord, MapValueRecord> recordMap,
-    //
-    HashMap<String, String> hashMap,
-    TreeMap<String, String> treeMap
+    Map<AnEnum, String> anEnumStringMap
 ) {
 }

--- a/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NullableAutoMapBag.java
+++ b/utils-tests/c_odd_types/src/main/java/io/github/cbarlin/aru/tests/c_odd_types/NullableAutoMapBag.java
@@ -8,9 +8,9 @@ import java.util.TreeMap;
 
 @AdvancedRecordUtils(
         builderOptions = @AdvancedRecordUtils.BuilderOptions(
-                buildNullCollectionToEmpty = false
+                buildNullCollectionToEmpty = false,
                 // These should be the defaults
-                // builtCollectionType = BuiltCollectionType.JAVA_IMMUTABLE,
+                builtCollectionType = AdvancedRecordUtils.BuiltCollectionType.AUTO
                 // createAdderMethods = true
         ),
         diffable = true,
@@ -31,8 +31,6 @@ public record NullableAutoMapBag(
     Map<String, String> stringStringMap,
     Map<String, AnEnum> stringAnEnumMap,
     Map<MapKeyRecord, MapValueRecord> recordMap,
-    //
-    HashMap<String, String> hashMap,
-    TreeMap<String, String> treeMap
+    Map<AnEnum, String> anEnumStringMap
 ) {
 }

--- a/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/MapsTest.java
+++ b/utils-tests/c_odd_types/src/test/java/io/github/cbarlin/aru/tests/c_odd_types/MapsTest.java
@@ -28,12 +28,6 @@ class MapsTest {
         assertThat(built.stringStringMap())
                 .hasSize(1)
                 .containsEntry("AA", "BB");
-        assertThat(built.hashMap())
-                .isNotNull()
-                .isEmpty();
-        assertThat(built.treeMap())
-                .isNotNull()
-                .isEmpty();
         assertThat(built.recordMap())
                 .isNotNull()
                 .isEmpty();
@@ -52,12 +46,6 @@ class MapsTest {
         assertThat(built.stringStringMap())
                 .hasSize(1)
                 .containsEntry("AA", "BB");
-        assertThat(built.hashMap())
-                .isNotNull()
-                .isEmpty();
-        assertThat(built.treeMap())
-                .isNotNull()
-                .isEmpty();
         assertThat(built.recordMap())
                 .isNotNull()
                 .isEmpty();
@@ -65,6 +53,6 @@ class MapsTest {
                 .isNotNull()
                 .isEmpty();
         assertDoesNotThrow(() -> built.stringStringMap().put("A", "B"));
-        assertThrows(UnsupportedOperationException.class, () -> built.stringAnEnumMap().put("A", AnEnum.ONE));
+        assertDoesNotThrow(() -> built.stringAnEnumMap().put("A", AnEnum.ONE));
     }
 }

--- a/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/NonNullableAutoMapBag.java
+++ b/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/NonNullableAutoMapBag.java
@@ -1,17 +1,15 @@
-package io.github.cbarlin.aru.tests.c_odd_types;
+package io.github.cbarlin.aru.tests.d_eclipse_collections;
 
 import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
+import io.github.cbarlin.aru.tests.b_infer_xml.InferMatchingNameUtils;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.primitive.ImmutableCharBooleanMap;
+import org.eclipse.collections.api.map.primitive.MutableIntShortMap;
 
 @AdvancedRecordUtils(
         builderOptions = @AdvancedRecordUtils.BuilderOptions(
                 builtCollectionType = AdvancedRecordUtils.BuiltCollectionType.AUTO
-                // These should be the defaults:
-                // buildNullCollectionToEmpty = true
-                // createAdderMethods = true
         ),
         diffable = true,
         diffOptions = @AdvancedRecordUtils.DiffOptions(
@@ -25,12 +23,14 @@ import java.util.TreeMap;
         mergerOptions = @AdvancedRecordUtils.MergerOptions(
                 staticMethodsAddedToUtils = true
         ),
-        wither = true
+        importTargets = {
+                InferMatchingNameUtils.class
+        }
 )
 public record NonNullableAutoMapBag(
-    Map<String, String> stringStringMap,
-    Map<String, AnEnum> stringAnEnumMap,
-    Map<MapKeyRecord, MapValueRecord> recordMap,
-    Map<AnEnum, String> anEnumStringMap
+    ImmutableMap<String, String> immutableMap,
+    MutableMap<String, String> mutableMap,
+    ImmutableCharBooleanMap immutableCharBooleanMap,
+    MutableIntShortMap intShortMap
 ) {
 }

--- a/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/NonNullableImmutableCollectionBag.java
+++ b/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/NonNullableImmutableCollectionBag.java
@@ -1,12 +1,8 @@
 package io.github.cbarlin.aru.tests.d_eclipse_collections;
 
-import com.carrotsearch.hppc.ByteArrayList;
 import com.carrotsearch.hppc.CharArrayList;
-import com.carrotsearch.hppc.IntArrayList;
-import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntStack;
 import com.carrotsearch.hppc.LongHashSet;
-import com.carrotsearch.hppc.LongSet;
 import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
 import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.BuilderOptions;
 import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.NameGeneration;

--- a/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/NonNullableImmutableMapBag.java
+++ b/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/NonNullableImmutableMapBag.java
@@ -1,0 +1,38 @@
+package io.github.cbarlin.aru.tests.d_eclipse_collections;
+
+import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
+import io.github.cbarlin.aru.tests.b_infer_xml.InferMatchingNameUtils;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.primitive.ImmutableCharBooleanMap;
+import org.eclipse.collections.api.map.primitive.MutableIntShortMap;
+
+@AdvancedRecordUtils(
+        builderOptions = @AdvancedRecordUtils.BuilderOptions(
+                // These should both be the defaults
+                // builtCollectionType = BuiltCollectionType.JAVA_IMMUTABLE,
+                // buildNullCollectionToEmpty = true
+        ),
+        diffable = true,
+        diffOptions = @AdvancedRecordUtils.DiffOptions(
+                staticMethodsAddedToUtils = true
+        ),
+        xmlable = true,
+        xmlOptions = @AdvancedRecordUtils.XmlOptions(
+                inferXmlElementName = AdvancedRecordUtils.NameGeneration.MATCH
+        ),
+        merger = true,
+        mergerOptions = @AdvancedRecordUtils.MergerOptions(
+                staticMethodsAddedToUtils = true
+        ),
+        importTargets = {
+                InferMatchingNameUtils.class
+        }
+)
+public record NonNullableImmutableMapBag(
+    ImmutableMap<String, String> immutableMap,
+    MutableMap<String, String> mutableMap,
+    ImmutableCharBooleanMap immutableCharBooleanMap,
+    MutableIntShortMap intShortMap
+) {
+}

--- a/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/NullableAutoMapBag.java
+++ b/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/NullableAutoMapBag.java
@@ -1,0 +1,37 @@
+package io.github.cbarlin.aru.tests.d_eclipse_collections;
+
+import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
+import io.github.cbarlin.aru.tests.b_infer_xml.InferMatchingNameUtils;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.primitive.ImmutableCharBooleanMap;
+import org.eclipse.collections.api.map.primitive.MutableIntShortMap;
+
+@AdvancedRecordUtils(
+        builderOptions = @AdvancedRecordUtils.BuilderOptions(
+                builtCollectionType = AdvancedRecordUtils.BuiltCollectionType.AUTO,
+                buildNullCollectionToEmpty = false
+        ),
+        diffable = true,
+        diffOptions = @AdvancedRecordUtils.DiffOptions(
+                staticMethodsAddedToUtils = true
+        ),
+        xmlable = true,
+        xmlOptions = @AdvancedRecordUtils.XmlOptions(
+                inferXmlElementName = AdvancedRecordUtils.NameGeneration.MATCH
+        ),
+        merger = true,
+        mergerOptions = @AdvancedRecordUtils.MergerOptions(
+                staticMethodsAddedToUtils = true
+        ),
+        importTargets = {
+                InferMatchingNameUtils.class
+        }
+)
+public record NullableAutoMapBag(
+    ImmutableMap<String, String> immutableMap,
+    MutableMap<String, String> mutableMap,
+    ImmutableCharBooleanMap immutableCharBooleanMap,
+    MutableIntShortMap intShortMap
+) {
+}

--- a/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/NullableImmutableMapBag.java
+++ b/utils-tests/d_eclipse_collections/src/main/java/io/github/cbarlin/aru/tests/d_eclipse_collections/NullableImmutableMapBag.java
@@ -1,17 +1,15 @@
-package io.github.cbarlin.aru.tests.c_odd_types;
+package io.github.cbarlin.aru.tests.d_eclipse_collections;
 
 import io.github.cbarlin.aru.annotations.AdvancedRecordUtils;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
+import io.github.cbarlin.aru.tests.b_infer_xml.InferMatchingNameUtils;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.primitive.ImmutableCharBooleanMap;
+import org.eclipse.collections.api.map.primitive.MutableIntShortMap;
 
 @AdvancedRecordUtils(
         builderOptions = @AdvancedRecordUtils.BuilderOptions(
-                builtCollectionType = AdvancedRecordUtils.BuiltCollectionType.JAVA_IMMUTABLE,
                 buildNullCollectionToEmpty = false
-                // These should be the defaults
-                // createAdderMethods = true
         ),
         diffable = true,
         diffOptions = @AdvancedRecordUtils.DiffOptions(
@@ -25,12 +23,14 @@ import java.util.TreeMap;
         mergerOptions = @AdvancedRecordUtils.MergerOptions(
                 staticMethodsAddedToUtils = true
         ),
-        wither = true
+        importTargets = {
+                InferMatchingNameUtils.class
+        }
 )
 public record NullableImmutableMapBag(
-    Map<String, String> stringStringMap,
-    Map<String, AnEnum> stringAnEnumMap,
-    Map<MapKeyRecord, MapValueRecord> recordMap,
-    Map<AnEnum, String> anEnumStringMap
+    ImmutableMap<String, String> immutableMap,
+    MutableMap<String, String> mutableMap,
+    ImmutableCharBooleanMap immutableCharBooleanMap,
+    MutableIntShortMap intShortMap
 ) {
 }

--- a/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/CollectionsTests.java
+++ b/utils-tests/d_eclipse_collections/src/test/java/io/github/cbarlin/aru/tests/d_eclipse_collections/CollectionsTests.java
@@ -3,6 +3,7 @@ package io.github.cbarlin.aru.tests.d_eclipse_collections;
 import io.github.cbarlin.aru.tests.a_core_dependency.AnEnumInDep;
 import io.github.cbarlin.aru.tests.b_infer_xml.InferMatchingNameUtils;
 import io.github.cbarlin.aru.tests.xml_util.ConvertToXml;
+import org.eclipse.collections.api.factory.Maps;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;


### PR DESCRIPTION
While we do drop support for HashMap and TreeMap, we gain parity with standard collections in terms of feature set for basic `Map` types, plus also Eclipse maps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broadened Map support across generated records: Java EnumMap, Eclipse Collections and HPPC variants (including primitive maps), with builder setters/getters, add/remove, specialised builder methods, and automatic nullable/non‑null & mutable/immutable behaviours.
  * New diff and merge helpers and generated accessor/result methods for Map fields.
  * New internal selection/wrapping for appropriate Map handling per component.

* **Tests**
  * Added and updated map-focused test records and unit tests to cover new Map behaviours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->