### PR TITLE
Add support for specifying `SuppressWarnings` annotations

### DIFF
--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.java
@@ -128,6 +128,15 @@ public @interface AdvancedRecordUtils {
      * @since 0.7.8
      */
     boolean addHigherKindedJImportAnnotation() default false;
+
+    /**
+     * Should we add an {@link SuppressWarnings} annotation?
+     * <p>
+     * Useful if you want to ignore warnings in generated code
+     *
+     * @since 0.9.1
+     */
+    SuppressWarnings addSuppressWarningsAnnotation() default @SuppressWarnings({});
     //#endregion
 
     //#region Generated target options

--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtilsFull.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtilsFull.java
@@ -38,7 +38,8 @@ import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.MergerOptions;
     ),
     mergerOptions = @MergerOptions(
         staticMethodsAddedToUtils = true
-    )
+    ),
+    addSuppressWarningsAnnotation = @SuppressWarnings({"exports"})
 )
 public @interface AdvancedRecordUtilsFull {
 

--- a/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtilsFull.java
+++ b/advanced-record-utils-annotations/src/main/java/io/github/cbarlin/aru/annotations/AdvancedRecordUtilsFull.java
@@ -38,8 +38,7 @@ import io.github.cbarlin.aru.annotations.AdvancedRecordUtils.MergerOptions;
     ),
     mergerOptions = @MergerOptions(
         staticMethodsAddedToUtils = true
-    ),
-    addSuppressWarningsAnnotation = @SuppressWarnings({"exports"})
+    )
 )
 public @interface AdvancedRecordUtilsFull {
 

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/impl/visitors/SuppressWarningsInterfaceVisitor.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/impl/visitors/SuppressWarningsInterfaceVisitor.java
@@ -1,0 +1,48 @@
+package io.github.cbarlin.aru.core.impl.visitors;
+
+import io.avaje.inject.Component;
+import io.github.cbarlin.aru.core.AdvRecUtilsSettings;
+import io.github.cbarlin.aru.core.ClaimableOperation;
+import io.github.cbarlin.aru.core.types.AnalysedInterface;
+import io.github.cbarlin.aru.core.types.AnalysedRecord;
+import io.github.cbarlin.aru.core.types.OperationType;
+import io.github.cbarlin.aru.core.visitors.InterfaceVisitor;
+import io.github.cbarlin.aru.core.visitors.RecordVisitor;
+import io.github.cbarlin.aru.core.wiring.CorePerInterfaceScope;
+import io.github.cbarlin.aru.core.wiring.CorePerRecordScope;
+import io.github.cbarlin.aru.prism.prison.AdvancedRecordUtilsPrism;
+import io.micronaut.sourcegen.javapoet.AnnotationSpec;
+import io.micronaut.sourcegen.javapoet.TypeSpec;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@CorePerInterfaceScope
+public class SuppressWarningsInterfaceVisitor extends InterfaceVisitor {
+    private final AdvRecUtilsSettings settings;
+    private final TypeSpec.Builder utilsClassBuilder;
+
+    protected SuppressWarningsInterfaceVisitor(final AnalysedInterface analysedInterface) {
+        super(new ClaimableOperation("CoreCopySuppressWarnings", OperationType.CLASS), analysedInterface);
+        settings = analysedInterface.settings();
+        utilsClassBuilder = analysedInterface.utilsClassBuilder();
+    }
+
+    @Override
+    public int specificity() {
+        return 0;
+    }
+
+    @Override
+    protected boolean visitInterfaceImpl() {
+        final List<String> warnings = Optional.ofNullable(settings.prism().addSuppressWarningsAnnotation())
+                .map(AdvancedRecordUtilsPrism.SuppressWarningsPrism::value)
+                .orElseGet(List::of);
+        if (!warnings.isEmpty()) {
+            utilsClassBuilder.addAnnotation(AnnotationSpec.get(settings.prism().addSuppressWarningsAnnotation().mirror));
+            return true;
+        }
+        return false;
+    }
+}

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/impl/visitors/SuppressWarningsRecordVisitor.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/impl/visitors/SuppressWarningsRecordVisitor.java
@@ -1,0 +1,45 @@
+package io.github.cbarlin.aru.core.impl.visitors;
+
+import io.avaje.inject.Component;
+import io.github.cbarlin.aru.core.AdvRecUtilsSettings;
+import io.github.cbarlin.aru.core.ClaimableOperation;
+import io.github.cbarlin.aru.core.types.AnalysedRecord;
+import io.github.cbarlin.aru.core.types.OperationType;
+import io.github.cbarlin.aru.core.visitors.RecordVisitor;
+import io.github.cbarlin.aru.core.wiring.CorePerRecordScope;
+import io.github.cbarlin.aru.prism.prison.AdvancedRecordUtilsPrism;
+import io.micronaut.sourcegen.javapoet.AnnotationSpec;
+import io.micronaut.sourcegen.javapoet.TypeSpec;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@CorePerRecordScope
+public class SuppressWarningsRecordVisitor extends RecordVisitor {
+    private final AdvRecUtilsSettings settings;
+    private final TypeSpec.Builder utilsClassBuilder;
+
+    protected SuppressWarningsRecordVisitor(final AnalysedRecord analysedRecord) {
+        super(new ClaimableOperation("CoreCopySuppressWarnings", OperationType.CLASS), analysedRecord);
+        settings = analysedRecord.settings();
+        utilsClassBuilder = analysedRecord.utilsClassBuilder();
+    }
+
+    @Override
+    public int specificity() {
+        return 0;
+    }
+
+    @Override
+    protected boolean visitStartOfClassImpl() {
+        final List<String> warnings = Optional.ofNullable(settings.prism().addSuppressWarningsAnnotation())
+                .map(AdvancedRecordUtilsPrism.SuppressWarningsPrism::value)
+                .orElseGet(List::of);
+        if (!warnings.isEmpty()) {
+            utilsClassBuilder.addAnnotation(AnnotationSpec.get(settings.prism().addSuppressWarningsAnnotation().mirror));
+            return true;
+        }
+        return false;
+    }
+}

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/mirrorhandlers/ToPrettierAnnotationSpec.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/mirrorhandlers/ToPrettierAnnotationSpec.java
@@ -38,6 +38,9 @@ public final class ToPrettierAnnotationSpec {
             final String valueName = entry.getKey().getSimpleName().toString();
             av.accept(nestedVisitor, valueName);
         }
+        if (name.simpleName().equals("SuppressWarnings") && (!builder.members.containsKey("value"))) {
+            builder.addMember("value", "{}");
+        }
         return builder.build();
     }
 

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/mirrorhandlers/ToPrettierAnnotationSpec.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/mirrorhandlers/ToPrettierAnnotationSpec.java
@@ -38,7 +38,7 @@ public final class ToPrettierAnnotationSpec {
             final String valueName = entry.getKey().getSimpleName().toString();
             av.accept(nestedVisitor, valueName);
         }
-        if (name.simpleName().equals("SuppressWarnings") && (!builder.members.containsKey("value"))) {
+        if (name.canonicalName().equals("java.lang.SuppressWarnings") && (!builder.members.containsKey("value"))) {
             builder.addMember("value", "{}");
         }
         return builder.build();

--- a/docs/generated-code/options/aru-top-suppress.adoc
+++ b/docs/generated-code/options/aru-top-suppress.adoc
@@ -1,0 +1,15 @@
+****
+
+.Generated annotation for `+*Utils+` classes
+[%collapsible]
+=====
+[source,java]
+----
+@SuppressWarnings({"exports"})
+public final class RootItemUtils implements GeneratedUtil {
+
+}
+----
+=====
+
+****

--- a/docs/options/aru-top-general.adoc
+++ b/docs/options/aru-top-general.adoc
@@ -101,7 +101,7 @@ public record Person(String name, int age) {}
 ====
 Defines the type of logging performed by generated code, if any.
 
-*Type*:: https://javadoc.io/doc/io.github.cbarlin/advanced-record-utils-annotations/latest/io.github.cbarlin.aru.annotations/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.LoggingGeneration.html[`+LoggingGeneration+`]
+*Type*:: https://javadoc.io/doc/io.github.cbarlin/advanced-record-utils-annotations/latest/io.github.cbarlin.aru.annotations/io/github/cbarlin/aru/annotations/AdvancedRecordUtils.LoggingGeneration.html[`+LoggingGeneration+`^]
 *Default*:: `+LoggingGeneration.NONE+`
 
 .Usage: Choosing a setting
@@ -136,9 +136,9 @@ include::../generated-code/options/aru-top-logging.adoc[]
 .`+addJsonbImportAnnotation+`
 [%collapsible]
 ====
-Enables or disables the generation of an https://javadoc.io/doc/io.avaje/avaje-jsonb/latest/io.avaje.jsonb/io/avaje/jsonb/Json.Import.html[Avaje `+@Json.Import+`] annotation on the `+*Utils+` classes.
+Enables or disables the generation of an https://javadoc.io/doc/io.avaje/avaje-jsonb/latest/io.avaje.jsonb/io/avaje/jsonb/Json.Import.html[Avaje `+@Json.Import+`^] annotation on the `+*Utils+` classes.
 
-You can read more about Avaje jsonb on their https://avaje.io/jsonb/[documentation page].
+You can read more about Avaje jsonb on their https://avaje.io/jsonb/[documentation page^].
 
 *Type*:: `+boolean+`
 *Default*:: `+false+`
@@ -161,9 +161,9 @@ include::../generated-code/options/aru-top-general.adoc[]
 .`+addHigherKindedJImportAnnotation+`
 [%collapsible]
 ====
-Enables or disables the generation of an https://javadoc.io/doc/io.github.higher-kinded-j/hkj-annotations/latest/org.higherkindedj.annotations/org/higherkindedj/optics/annotations/ImportOptics.html[Higher-Kinded-J `+@ImportOptics+`] annotation on the `+*Utils+` classes.
+Enables or disables the generation of an https://javadoc.io/doc/io.github.higher-kinded-j/hkj-annotations/latest/org.higherkindedj.annotations/org/higherkindedj/optics/annotations/ImportOptics.html[Higher-Kinded-J `+@ImportOptics+`^] annotation on the `+*Utils+` classes.
 
-You can read more about Higher-Kinded-J on their https://higher-kinded-j.github.io/latest/[documentation page].
+You can read more about Higher-Kinded-J on their https://higher-kinded-j.github.io/latest/[documentation page^].
 
 *Type*:: `+boolean+`
 *Default*:: `+false+`
@@ -184,7 +184,7 @@ include::../generated-code/options/aru-top-hkj.adoc[]
 .`+addSuppressWarningsAnnotation+`
 [%collapsible]
 ====
-Enables or disables the generation of an https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/SuppressWarnings.html[`+@SuppressWarnings+`] annotation on the `+*Utils+` classes.
+Enables or disables the generation of an https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/SuppressWarnings.html[`+@SuppressWarnings+`^] annotation on the `+*Utils+` classes.
 
 *Type*:: `+@SuppressWarnings+`
 *Default*:: `+@SuppressWarnings({})+` (as in, no warnings suppressed)

--- a/docs/options/aru-top-general.adoc
+++ b/docs/options/aru-top-general.adoc
@@ -180,3 +180,28 @@ Particularly useful on large trees of records, as the <<#use-cascading,cascading
 include::../generated-code/options/aru-top-hkj.adoc[]
 
 ====
+
+.`+addSuppressWarningsAnnotation+`
+[%collapsible]
+====
+Enables or disables the generation of an https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/SuppressWarnings.html[`+@SuppressWarnings+`] annotation on the `+*Utils+` classes.
+
+*Type*:: `+@SuppressWarnings+`
+*Default*:: `+@SuppressWarnings({})+` (as in, no warnings suppressed)
+
+.Usage: Add to any place you can add the annotation
+[source,java]
+----
+@AdvancedRecordUtils(addSuppressWarningsAnnotation = @SuppressWarnings({"exports"}))
+public record Person(String name, int age) {}
+----
+
+While generated code shouldn't have warnings by default (and if it does, we would consider it a bug), some settings you specify may cause warnings to be generated such as:
+
+* Having XML generation enabled, but the XML module not marked as `+requires transitive+` in your `+module-info.java+`
+* Requesting that an interface is returned from `+build+` instead of a concrete type, but that interface isn't in a package exported in your `+module-info.java+`
+* Certain concrete collection types may generate casts, which Java may consider to be "unchecked" due to type erasure.
+
+include::../generated-code/options/aru-top-suppress.adoc[]
+
+====

--- a/utils-tests/a_core_dependency/src/main/java/io/github/cbarlin/aru/tests/a_core_dependency/hidden/AnotherMetaAnnotation.java
+++ b/utils-tests/a_core_dependency/src/main/java/io/github/cbarlin/aru/tests/a_core_dependency/hidden/AnotherMetaAnnotation.java
@@ -10,7 +10,12 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.TYPE;
 
-@AdvancedRecordUtils(logGeneration = LoggingGeneration.SLF4J_GENERATED_UTIL_INTERFACE)
+@AdvancedRecordUtils(
+        logGeneration = LoggingGeneration.SLF4J_GENERATED_UTIL_INTERFACE,
+        // There are no actual warnings generated, we are just confirming it is actually added correctly
+        //   when requested
+        addSuppressWarningsAnnotation = @SuppressWarnings({"exports", "unchecked"})
+)
 @Target({TYPE})
 @Retention(RetentionPolicy.CLASS)
 @Inherited

--- a/utils-tests/c_deeply_nested_commons_lang/src/main/java/io/github/cbarlin/aru/tests/cdncl/RootItem.java
+++ b/utils-tests/c_deeply_nested_commons_lang/src/main/java/io/github/cbarlin/aru/tests/cdncl/RootItem.java
@@ -21,7 +21,9 @@ import jakarta.xml.bind.annotation.XmlType;
     merger = true,
     wither = true,
     witherOptions = @WitherOptions(convertToBuilder = "toBuilder"),
-    xmlable = true
+    xmlable = true,
+    // We aren't actually suppressing any warnings here, just checking it gets added correctly
+    addSuppressWarningsAnnotation = @SuppressWarnings({"exports"})
 )
 @XmlRootElement(name = "RootItem", namespace = "ns://nxA")
 @XmlType(name = "", propOrder = {"yetAnotherField"})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Added a new configuration option to control whether generated utility classes include `@SuppressWarnings` annotations, allowing developers to suppress compiler warnings on generated code as needed.

**Documentation**
* Updated documentation to describe the new suppress warnings configuration option with usage examples and guidance on potential remaining warning sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->