### PR TITLE
Attempt to enforce processing order

### DIFF
--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/AdvRecUtilsProcessor.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/AdvRecUtilsProcessor.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -13,6 +14,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 
+import io.github.cbarlin.aru.core.artifacts.sorting.ElementComparator;
 import org.jspecify.annotations.Nullable;
 
 import io.avaje.inject.BeanScope;
@@ -92,14 +94,14 @@ public final class AdvRecUtilsProcessor extends AbstractProcessor {
     private void findAndProcessTargets(final BeanScope scope, final RoundEnvironment roundEnv, final SupportedAnnotations supportedAnnotations) {
         final UtilsProcessingContext context = scope.get(UtilsProcessingContext.class);
         final List<TargetAnalyser> analysers = scope.list(TargetAnalyser.class);
-        final Set<TypeElement> firstLoop = Set.copyOf(supportedAnnotations.annotations());
+        final Set<TypeElement> firstLoop = new TreeSet<>(supportedAnnotations.annotations());
         for (final TypeElement typeElement : firstLoop) {
             for (final Element annotatedElement : roundEnv.getElementsAnnotatedWith(typeElement)) {
                 context.analyseRootElement(annotatedElement, analysers);
             }
         }
         // In case it got added to during the analysis
-        for (final TypeElement typeElement : Set.copyOf(supportedAnnotations.annotations())) {
+        for (final TypeElement typeElement : new TreeSet<>(supportedAnnotations.annotations())) {
             if (firstLoop.contains(typeElement)) {
                 continue;
             }
@@ -108,16 +110,18 @@ public final class AdvRecUtilsProcessor extends AbstractProcessor {
             }
         }
         context.matchInterfaces();
-        context.injectAllRootElements(Set.copyOf(supportedAnnotations.annotations()), getSupportedAnnotationTypes());
+        context.injectAllRootElements(new TreeSet<>(supportedAnnotations.annotations()), getSupportedAnnotationTypes());
         context.processElements(scope);
     }
 
-    private void findMetaAnnotations(final RoundEnvironment roundEnv, final Set<TypeElement> supportedAnnotations) {
-        for(final TypeElement annoType : Set.copyOf(supportedAnnotations)) {
-            for(final Element annotatedElement : roundEnv.getElementsAnnotatedWith(annoType)) {
-                if (annotatedElement instanceof final TypeElement typeAnnoElement && ElementKind.ANNOTATION_TYPE.equals(typeAnnoElement.getKind())) {
-                    supportedAnnotations.add(typeAnnoElement);
-                }
+    private void findMetaAnnotations(final RoundEnvironment roundEnv, final TreeSet<TypeElement> supportedAnnotations) {
+        final TreeSet<Element> annotatedElements = new TreeSet<>(ElementComparator.INSTANCE);
+        for(final TypeElement annoType : new TreeSet<>(supportedAnnotations)) {
+            annotatedElements.addAll(roundEnv.getElementsAnnotatedWith(annoType));
+        }
+        for(final Element annotatedElement : annotatedElements) {
+            if (annotatedElement instanceof final TypeElement typeAnnoElement && ElementKind.ANNOTATION_TYPE.equals(typeAnnoElement.getKind())) {
+                supportedAnnotations.add(typeAnnoElement);
             }
         }
     }

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/UtilsProcessingContext.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/UtilsProcessingContext.java
@@ -4,6 +4,7 @@ import io.avaje.inject.BeanScope;
 import io.avaje.inject.Component;
 import io.github.cbarlin.aru.core.analysers.TargetAnalyser;
 import io.github.cbarlin.aru.core.analysers.TargetAnalysisResult;
+import io.github.cbarlin.aru.core.artifacts.sorting.ElementComparator;
 import io.github.cbarlin.aru.core.factories.BeanScopeFactory;
 import io.github.cbarlin.aru.core.impl.ScopeHolder;
 import io.github.cbarlin.aru.core.types.AnalysedInterface;
@@ -43,6 +44,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Predicate;
 
@@ -50,11 +53,11 @@ import java.util.function.Predicate;
 @CoreGlobalScope
 public final class UtilsProcessingContext {
 
-    private final Map<TypeElement, ProcessingTarget> analysedTypes = new HashMap<>();
+    private final Map<TypeElement, ProcessingTarget> analysedTypes = new TreeMap<>(ElementComparator.INSTANCE);
     private final Set<ExecutableElement> processedConverters = new HashSet<>();
     private final HashMap<TypeName, Queue<AnalysedTypeConverter>> analysedConverters = new HashMap<>();
     private final Set<TypeElement> processedElements = new HashSet<>();
-    private final Set<Element> rootElements = new HashSet<>();
+    private final Set<Element> rootElements = new TreeSet<>(ElementComparator.INSTANCE);
 
     public ProcessingEnvironment processingEnv() {
         return APContext.processingEnv();
@@ -232,8 +235,9 @@ public final class UtilsProcessingContext {
         ) {
             // Scope holder handles `close` on the BeanScope
             final BeanScope perTargetBeanScope = scopeHolder.scope();
-            perTargetBeanScope.list(InterfaceVisitor.class)
-                .forEach(InterfaceVisitor::visitInterface);
+            final List<InterfaceVisitor> perInterfaceVisitors = perTargetBeanScope.list(InterfaceVisitor.class);
+            Collections.sort(perInterfaceVisitors);
+            perInterfaceVisitors.forEach(InterfaceVisitor::visitInterface);
 
             writeFile(analysedInterface);
         }

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/artifacts/sorting/ElementComparator.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/artifacts/sorting/ElementComparator.java
@@ -8,7 +8,7 @@ import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
 import java.util.Comparator;
 /**
- * Comparator for {`@link` Element} instances that provides deterministic ordering
+ * Comparator for {@link Element} instances that provides deterministic ordering
  * to ensure reproducible builds. Elements are ordered by type hierarchy (modules,
  * packages, executables, then types), with ties broken by qualified or simple name.
  */

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/artifacts/sorting/ElementComparator.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/artifacts/sorting/ElementComparator.java
@@ -1,0 +1,29 @@
+package io.github.cbarlin.aru.core.artifacts.sorting;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.ModuleElement;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.QualifiedNameable;
+import javax.lang.model.element.TypeElement;
+import java.util.Comparator;
+
+public final class ElementComparator {
+
+    public static final Comparator<Element> INSTANCE = createComparator();
+
+    private static Comparator<Element> createComparator() {
+        return Comparator.comparingInt(ElementComparator::elementTypeToNumber)
+                .thenComparing(e -> (e instanceof final QualifiedNameable qualifiedNameable) ? qualifiedNameable.getQualifiedName().toString() : e.getSimpleName().toString());
+    }
+
+    private static int elementTypeToNumber(final Element el) {
+        return switch (el) {
+            case final ModuleElement _ -> 1;
+            case final PackageElement _ -> 2;
+            case final ExecutableElement _ -> 3;
+            case final TypeElement t -> 4 + t.getKind().ordinal();
+            default -> 9999;
+        };
+    }
+}

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/artifacts/sorting/ElementComparator.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/artifacts/sorting/ElementComparator.java
@@ -7,14 +7,34 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
 import java.util.Comparator;
-
+/**
+ * Comparator for {`@link` Element} instances that provides deterministic ordering
+ * to ensure reproducible builds. Elements are ordered by type hierarchy (modules,
+ * packages, executables, then types), with ties broken by qualified or simple name.
+ */
 public final class ElementComparator {
 
+    /**
+     * The element comparator. Orders elements by type hierarchy with ties broken by name.
+     *
+     * @see ElementComparator
+     */
     public static final Comparator<Element> INSTANCE = createComparator();
 
+    /**
+     * Creates the element comparator. First orders by element type rank,
+     * then by qualified name (when available) or simple name as a tiebreaker.
+     */
     private static Comparator<Element> createComparator() {
         return Comparator.comparingInt(ElementComparator::elementTypeToNumber)
-                .thenComparing(e -> (e instanceof final QualifiedNameable qualifiedNameable) ? qualifiedNameable.getQualifiedName().toString() : e.getSimpleName().toString());
+                .thenComparing(ElementComparator::elementName);
+    }
+
+    private static String elementName(final Element element) {
+        if (element instanceof final QualifiedNameable qualifiedNameable) {
+            return qualifiedNameable.getQualifiedName().toString();
+        }
+        return element.getSimpleName().toString();
     }
 
     private static int elementTypeToNumber(final Element el) {

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/SupportedAnnotations.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/SupportedAnnotations.java
@@ -1,10 +1,10 @@
 package io.github.cbarlin.aru.core.factories;
 
 import javax.lang.model.element.TypeElement;
-import java.util.HashSet;
+import java.util.TreeSet;
 
 public record SupportedAnnotations (
-    HashSet<TypeElement> annotations
+    TreeSet<TypeElement> annotations
 ) {
 
 }

--- a/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/SupportedAnnotationsFactory.java
+++ b/aru-processor-core/src/main/java/io/github/cbarlin/aru/core/factories/SupportedAnnotationsFactory.java
@@ -7,6 +7,7 @@ import io.github.cbarlin.aru.annotations.AdvancedRecordUtilsFull;
 import io.github.cbarlin.aru.annotations.TypeConverter;
 import io.github.cbarlin.aru.core.APContext;
 import io.github.cbarlin.aru.core.OptionalClassDetector;
+import io.github.cbarlin.aru.core.artifacts.sorting.ElementComparator;
 import io.github.cbarlin.aru.core.wiring.CoreGlobalScope;
 import io.micronaut.sourcegen.javapoet.ClassName;
 
@@ -16,7 +17,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.TreeSet;
 
 @Factory
 @CoreGlobalScope
@@ -33,15 +34,16 @@ public final class SupportedAnnotationsFactory {
         return new SupportedAnnotations(loadAnnotations(supportedAnnotations));
     }
 
-    private static HashSet<TypeElement> loadAnnotations(final Set<String> names) {
-        final var res = names.stream()
+    private static TreeSet<TypeElement> loadAnnotations(final Set<String> names) {
+        final TreeSet<TypeElement> elements = new TreeSet<>(ElementComparator.INSTANCE);
+        names.stream()
                 .map(APContext.elements()::getTypeElement)
                 .filter(Objects::nonNull)
                 .map(ClassName::get)
                 .map(OptionalClassDetector::loadAnnotation)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .collect(Collectors.toUnmodifiableSet());
-        return new HashSet<>(res);
+                .forEach(elements::add);
+        return elements;
     }
 }


### PR DESCRIPTION
I've managed to catch the resulting classes not being 100% reproducible, and I think the issue is due to the order in which elements are processed. Pre-sorting those elements, including the order in which annotations are actioned, will hopefully solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made annotation scanning and interface traversal deterministic so analysis and follow-up passes produce consistent, reproducible results across runs
  * Introduced stable ordering for elements, supported annotations and root element processing to ensure predictable traversal and sorting
  * No public API or signature changes; behavioural change is internal and improves reproducibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cbarlin/advanced-record-utils/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->