### PR TITLE
Optimise XML tag/namespace calculation

### DIFF
--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/ToXmlMethod.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/ToXmlMethod.java
@@ -67,6 +67,14 @@ public sealed abstract class ToXmlMethod extends XmlVisitor permits WriteIfaceTo
         return false;
     }
 
+    /// Generates code to handle default namespace changes for XML output.
+    ///
+    /// This takes into account:
+    ///  - if the user has specified an {@code XmlRootElement} annotation
+    ///  - if there is a requested namespace (via the {@code namespaceToPassDown} param)
+    ///  - if there's a current default namespace assigned
+    ///
+    /// @param methodBuilder the method specification builder to add statements to
     protected void writeChangeDefaultNamespace(final MethodSpec.Builder methodBuilder) {
         final ClassName xmlUtilCn = xmlStaticClass.className();
         if (xmlRootElementPrism.isPresent()) {

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/ToXmlMethod.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/ToXmlMethod.java
@@ -1,6 +1,7 @@
 package io.github.cbarlin.aru.impl.xml;
 
 import io.github.cbarlin.aru.core.ClaimableOperation;
+import io.github.cbarlin.aru.core.CommonsConstants;
 import io.github.cbarlin.aru.core.types.AnalysedComponent;
 import io.github.cbarlin.aru.core.types.AnalysedRecord;
 import io.github.cbarlin.aru.impl.xml.iface.WriteIfaceToXml;
@@ -8,7 +9,9 @@ import io.github.cbarlin.aru.impl.xml.utils.WriteStaticToXml;
 import io.github.cbarlin.aru.prism.prison.XmlRootElementPrism;
 import io.github.cbarlin.aru.prism.prison.XmlSchemaPrism;
 import io.github.cbarlin.aru.prism.prison.XmlTypePrism;
+import io.micronaut.sourcegen.javapoet.ClassName;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
+import io.micronaut.sourcegen.javapoet.TypeName;
 
 import javax.lang.model.element.TypeElement;
 import java.util.ArrayList;
@@ -18,14 +21,21 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+
+import static io.github.cbarlin.aru.impl.Constants.InternalReferenceNames.XML_DEFAULT_NAMESPACE_VAR_NAME;
+
+import static io.github.cbarlin.aru.impl.Constants.Names.STRING;
+
 public sealed abstract class ToXmlMethod extends XmlVisitor permits WriteIfaceToXml, WriteStaticToXml {
+
+    protected static final TypeName NULLABLE_STRING = STRING.withoutAnnotations().annotated(CommonsConstants.NULLABLE_ANNOTATION);
 
     protected final Optional<XmlRootElementPrism> xmlRootElementPrism;
     protected final Optional<XmlTypePrism> xmlTypePrism;
     protected final MethodSpec.Builder interfaceMethod;
     protected final MethodSpec.Builder staticMethod;
     protected final List<AnalysedComponent> components = new ArrayList<>();
-    protected final Set<AnalysedComponent> elCompontents = new HashSet<>();
+    protected final Set<AnalysedComponent> elComponents = new HashSet<>();
     protected final Set<AnalysedComponent> attrComponents = new HashSet<>();
 
     protected ToXmlMethod(
@@ -52,9 +62,36 @@ public sealed abstract class ToXmlMethod extends XmlVisitor permits WriteIfaceTo
         if (holder.xmlAttributeMapper().optionalInstanceOn(analysedComponent.element()).isPresent()) {
             attrComponents.add(analysedComponent);
         } else if (holder.xmlTransientMapper().optionalInstanceOn(analysedComponent.element()).isEmpty()) {
-            elCompontents.add(analysedComponent);
+            elComponents.add(analysedComponent);
         }
         return false;
+    }
+
+    protected void writeChangeDefaultNamespace(final MethodSpec.Builder methodBuilder) {
+        final ClassName xmlUtilCn = xmlStaticClass.className();
+        if (xmlRootElementPrism.isPresent()) {
+            methodBuilder.beginControlFlow("if ($T.$L != null) ", xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME)
+            .addStatement(
+                "output.setDefaultNamespace($T.$L)", xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME
+            )
+            .endControlFlow()
+            .addStatement(
+                "final $T namespaceToPassDown = ($T.$L != null) ? $T.$L : currentDefaultNamespace", NULLABLE_STRING, xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME, xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME
+            );
+
+        } else {
+            methodBuilder.addStatement(
+                "final $T defNs = ($T.$L != null && (requestedNamespace != null) && (!requestedNamespace.isBlank())) ? $T.$L : null", NULLABLE_STRING, xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME, xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME
+            )
+            .beginControlFlow("if (defNs != null)")
+            .addStatement(
+                "output.setDefaultNamespace(defNs)"
+            )
+            .endControlFlow()
+            .addStatement(
+                "final $T namespaceToPassDown = defNs != null ? defNs : currentDefaultNamespace", NULLABLE_STRING
+            );
+        }
     }
 
     protected final void configureNamespaceContext(final AnalysedRecord analysedRecord, final MethodSpec.Builder methodBuilder) {
@@ -87,7 +124,7 @@ public sealed abstract class ToXmlMethod extends XmlVisitor permits WriteIfaceTo
         if (isAlphabeticalAccessOrder) {
             final List<AnalysedComponent> toBeOrdered = new ArrayList<>();
             for(final AnalysedComponent component : components) {
-                if (elCompontents.contains(component) && (!(writeOrder.contains(component) || toBeOrdered.contains(component)))) {
+                if (elComponents.contains(component) && (!(writeOrder.contains(component) || toBeOrdered.contains(component)))) {
                     toBeOrdered.add(component);
                 }
             }
@@ -96,7 +133,7 @@ public sealed abstract class ToXmlMethod extends XmlVisitor permits WriteIfaceTo
         } else {
             // This will be declaration order then
             for(final AnalysedComponent component : components) {
-                if (elCompontents.contains(component) && (!writeOrder.contains(component))) {
+                if (elComponents.contains(component) && (!writeOrder.contains(component))) {
                     writeOrder.add(component);
                 }
             }
@@ -110,7 +147,7 @@ public sealed abstract class ToXmlMethod extends XmlVisitor permits WriteIfaceTo
     ) {
         for (final String prop : propOrder) {
             for(final AnalysedComponent component : components) {
-                if (prop.equals(component.name()) && (!writeOrder.contains(component)) && elCompontents.contains(component)) {
+                if (prop.equals(component.name()) && (!writeOrder.contains(component)) && elComponents.contains(component)) {
                     writeOrder.add(component);
                 }
             }

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/iface/WriteIfaceToXml.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/iface/WriteIfaceToXml.java
@@ -18,7 +18,6 @@ import org.apache.commons.lang3.StringUtils;
 import javax.lang.model.element.Modifier;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import static io.github.cbarlin.aru.impl.Constants.Names.OBJECTS;

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/iface/WriteIfaceToXml.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/iface/WriteIfaceToXml.java
@@ -2,7 +2,6 @@ package io.github.cbarlin.aru.impl.xml.iface;
 
 import io.github.cbarlin.aru.core.AnnotationSupplier;
 import io.github.cbarlin.aru.core.CommonsConstants;
-import io.github.cbarlin.aru.core.OptionalClassDetector;
 import io.github.cbarlin.aru.core.types.AnalysedComponent;
 import io.github.cbarlin.aru.impl.Constants.Claims;
 import io.github.cbarlin.aru.impl.types.TypeAliasComponent;
@@ -11,10 +10,8 @@ import io.github.cbarlin.aru.impl.xml.ToXmlMethod;
 import io.github.cbarlin.aru.impl.xml.XmlRecordHolder;
 import io.github.cbarlin.aru.prism.prison.XmlRootElementPrism;
 import io.github.cbarlin.aru.prism.prison.XmlTypePrism;
-import io.micronaut.sourcegen.javapoet.ClassName;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
 import io.micronaut.sourcegen.javapoet.ParameterSpec;
-import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
 import jakarta.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 
@@ -24,20 +21,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
-import static io.github.cbarlin.aru.core.CommonsConstants.Names.OPTIONAL;
-import static io.github.cbarlin.aru.impl.Constants.InternalReferenceNames.XML_DEFAULT_NAMESPACE_VAR_NAME;
 import static io.github.cbarlin.aru.impl.Constants.Names.OBJECTS;
 import static io.github.cbarlin.aru.impl.Constants.Names.STRING;
-import static io.github.cbarlin.aru.impl.Constants.Names.STRINGUTILS;
 import static io.github.cbarlin.aru.impl.Constants.Names.XML_STREAM_EXCEPTION;
 import static io.github.cbarlin.aru.impl.Constants.Names.XML_STREAM_WRITER;
 
 @Singleton
 @XmlPerRecordScope
 public final class WriteIfaceToXml extends ToXmlMethod {
-
-    private static final ParameterizedTypeName OPTIONAL_STRING = ParameterizedTypeName.get(OPTIONAL, STRING);
 
     public WriteIfaceToXml(final XmlRecordHolder xmlRecordHolder, final Optional<XmlTypePrism> xmlTypePrism, final Optional<XmlRootElementPrism> xmlRootElementPrism) {
         super(Claims.XML_IFACE_TO_XML, xmlRecordHolder, xmlTypePrism, xmlRootElementPrism);
@@ -48,53 +39,18 @@ public final class WriteIfaceToXml extends ToXmlMethod {
         return 0;
     }
 
-    private void writeChangeDefaultNamespace(final MethodSpec.Builder methodBuilder) {
-        final ClassName xmlUtilCn = xmlStaticClass.className();
-        if (xmlRootElementPrism.isPresent()) {
-            methodBuilder.beginControlFlow("if ($T.$L.isPresent()) ", xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME)
-            .addStatement(
-                "output.setDefaultNamespace($T.$L.get())", xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME
-            )
-            .endControlFlow()
-            .addStatement(
-                "final @$T String namespaceToPassDown = $T.$L.orElse(currentDefaultNamespace)", NULLABLE, xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME
-            );
-            
-        } else {
-            // Small statement, not worth creating a "WriteToXmlWithCommonsLang"
-            if (OptionalClassDetector.doesDependencyExist(STRINGUTILS)) {
-                methodBuilder.addStatement(
-                    "final $T defNs = $T.$L.filter(ignored -> $T.isBlank(requestedNamespace))", OPTIONAL_STRING, xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME, STRINGUTILS
-                );
-            } else {
-                methodBuilder.addStatement(
-                    "final $T defNs = $T.$L.filter(ignored -> requestedNamespace == null || (requestedNamespace.isBlank()))", OPTIONAL_STRING, xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME
-                );
-            }
-            methodBuilder.beginControlFlow("if (defNs.isPresent())")
-            .addStatement(
-                "output.setDefaultNamespace(defNs.get())"
-            )
-            .endControlFlow()
-            .addStatement(
-                "final @$T String namespaceToPassDown = defNs.orElse(currentDefaultNamespace)", NULLABLE
-            );
-        }
-    }
-
     @Override
     protected void visitEndOfClassImpl() {
         final MethodSpec.Builder methodBuilder = createMethod()
             .addStatement("final $T tag = $T.$L(requestedTagName)", STRING, xmlStaticClass.className(), "createTag")
-            .addStatement("final $T namespace = $T.createNamespace(requestedNamespace, currentDefaultNamespace)", OPTIONAL_STRING, xmlStaticClass.className());
+            .addStatement("final $T namespace = $T.createNamespace(requestedNamespace, currentDefaultNamespace)", NULLABLE_STRING, xmlStaticClass.className());
 
         configureNamespaceContext(analysedRecord, methodBuilder);
         writeChangeDefaultNamespace(methodBuilder);
-        methodBuilder.beginControlFlow("if (namespace.isPresent())")
-            .addStatement("final $T namespaceValue = namespace.get()", STRING)
-            .addStatement("output.writeStartElement(namespaceValue, tag)")
-            .beginControlFlow("if (!$T.equals(namespaceValue, currentDefaultNamespace))", OBJECTS)
-            .addStatement("output.writeDefaultNamespace(namespaceValue)")
+        methodBuilder.beginControlFlow("if (namespace != null)")
+            .addStatement("output.writeStartElement(namespace, tag)")
+            .beginControlFlow("if (!$T.equals(namespace, currentDefaultNamespace))", OBJECTS)
+            .addStatement("output.writeDefaultNamespace(namespace)")
             .endControlFlow()
             .nextControlFlow("else")
             .addStatement("output.writeStartElement(tag)")
@@ -103,7 +59,6 @@ public final class WriteIfaceToXml extends ToXmlMethod {
         addWriteOrderComment(methodBuilder);
         // OK, now to write out all the components... attributes first, then elements, then within those in order... booooooo
         final List<String> propOrder = xmlTypePrism.map(XmlTypePrism::propOrder)
-            .filter(Objects::nonNull)
             .map(props -> props.stream().filter(StringUtils::isNotBlank).toList())
             .orElse(List.of());
     
@@ -138,17 +93,17 @@ public final class WriteIfaceToXml extends ToXmlMethod {
                     .build()
             )
             .addParameter(
-                ParameterSpec.builder(STRING.annotated(CommonsConstants.NULLABLE_ANNOTATION), "requestedTagName", Modifier.FINAL)
+                ParameterSpec.builder(NULLABLE_STRING, "requestedTagName", Modifier.FINAL)
                     .addJavadoc("The tag name requested for this element. If null, will use the default tag name")
                     .build()
             )
             .addParameter(
-                ParameterSpec.builder(STRING.annotated(CommonsConstants.NULLABLE_ANNOTATION), "requestedNamespace", Modifier.FINAL)
+                ParameterSpec.builder(NULLABLE_STRING, "requestedNamespace", Modifier.FINAL)
                     .addJavadoc("The namespace requested for this element. If null, will use the default namespace (NOT the one on the element)")
                     .build()
             )
             .addParameter(
-                ParameterSpec.builder(STRING.annotated(CommonsConstants.NULLABLE_ANNOTATION), "currentDefaultNamespace", Modifier.FINAL)
+                ParameterSpec.builder(NULLABLE_STRING, "currentDefaultNamespace", Modifier.FINAL)
                     .addJavadoc("The current default namespace")
                     .build()
             )

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/WriteStaticToXml.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/WriteStaticToXml.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.StringUtils;
 import javax.lang.model.element.Modifier;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 

--- a/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/WriteStaticToXml.java
+++ b/advanced-record-utils-processor/src/main/java/io/github/cbarlin/aru/impl/xml/utils/WriteStaticToXml.java
@@ -12,11 +12,9 @@ import io.github.cbarlin.aru.impl.xml.XmlRecordHolder;
 import io.github.cbarlin.aru.prism.prison.XmlRootElementPrism;
 import io.github.cbarlin.aru.prism.prison.XmlSchemaPrism;
 import io.github.cbarlin.aru.prism.prison.XmlTypePrism;
-import io.micronaut.sourcegen.javapoet.ClassName;
 import io.micronaut.sourcegen.javapoet.FieldSpec;
 import io.micronaut.sourcegen.javapoet.MethodSpec;
 import io.micronaut.sourcegen.javapoet.ParameterSpec;
-import io.micronaut.sourcegen.javapoet.ParameterizedTypeName;
 import jakarta.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 
@@ -28,14 +26,12 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.ARU_GENERATED;
-import static io.github.cbarlin.aru.core.CommonsConstants.Names.NULLABLE;
 import static io.github.cbarlin.aru.core.CommonsConstants.Names.OPTIONAL;
 import static io.github.cbarlin.aru.impl.Constants.InternalReferenceNames.XML_DEFAULT_NAMESPACE_VAR_NAME;
 import static io.github.cbarlin.aru.impl.Constants.InternalReferenceNames.XML_DEFAULT_STRING;
 import static io.github.cbarlin.aru.impl.Constants.InternalReferenceNames.XML_DEFAULT_TAG_NAME_VAR_NAME;
 import static io.github.cbarlin.aru.impl.Constants.InternalReferenceNames.XML_PACKAGE_NAMESPACE_VAR_NAME;
 import static io.github.cbarlin.aru.impl.Constants.Names.OBJECTS;
-import static io.github.cbarlin.aru.impl.Constants.Names.PREDICATE;
 import static io.github.cbarlin.aru.impl.Constants.Names.STRING;
 import static io.github.cbarlin.aru.impl.Constants.Names.XML_STREAM_EXCEPTION;
 import static io.github.cbarlin.aru.impl.Constants.Names.XML_STREAM_WRITER;
@@ -50,7 +46,6 @@ public final class WriteStaticToXml extends ToXmlMethod {
     private static final ParameterSpec REQ_NS_PARAM = ParameterSpec.builder(STRING.annotated(CommonsConstants.NULLABLE_ANNOTATION), "requestedNamespace", Modifier.FINAL)
         .addJavadoc("The requested namespace when called")
         .build();
-    private static final ParameterizedTypeName OPTIONAL_STRING = ParameterizedTypeName.get(OPTIONAL, STRING);
 
     public WriteStaticToXml(final XmlRecordHolder xmlRecordHolder, final Optional<XmlTypePrism> xmlTypePrism, final Optional<XmlRootElementPrism> xmlRootElementPrism) {
         super(Claims.XML_STATIC_CLASS_TO_XML, xmlRecordHolder, xmlTypePrism, xmlRootElementPrism);
@@ -83,13 +78,13 @@ public final class WriteStaticToXml extends ToXmlMethod {
             )
             .ifPresentOrElse(
                 namespace -> xmlStaticClass.addField(
-                    FieldSpec.builder(OPTIONAL_STRING, XML_DEFAULT_NAMESPACE_VAR_NAME, Modifier.FINAL, Modifier.STATIC, Modifier.PRIVATE)
-                        .initializer("$T.of($S)", OPTIONAL, namespace)
+                    FieldSpec.builder(NULLABLE_STRING, XML_DEFAULT_NAMESPACE_VAR_NAME, Modifier.FINAL, Modifier.STATIC, Modifier.PRIVATE)
+                        .initializer("$S", namespace)
                         .build()
                 ),
                 () -> xmlStaticClass.addField(
-                    FieldSpec.builder(OPTIONAL_STRING, XML_DEFAULT_NAMESPACE_VAR_NAME, Modifier.FINAL, Modifier.STATIC, Modifier.PRIVATE)
-                        .initializer("$T.empty()", OPTIONAL)
+                    FieldSpec.builder(NULLABLE_STRING, XML_DEFAULT_NAMESPACE_VAR_NAME, Modifier.FINAL, Modifier.STATIC, Modifier.PRIVATE)
+                        .initializer("null")
                         .build()
                 )
             );
@@ -100,13 +95,13 @@ public final class WriteStaticToXml extends ToXmlMethod {
                 .filter(Predicate.not(XML_DEFAULT_STRING::equals))
                 .ifPresentOrElse(
                     namespace -> xmlStaticClass.addField(
-                        FieldSpec.builder(OPTIONAL_STRING, XML_PACKAGE_NAMESPACE_VAR_NAME, Modifier.FINAL, Modifier.STATIC, Modifier.PRIVATE)
-                            .initializer("$T.of($S)", OPTIONAL, namespace)
+                        FieldSpec.builder(NULLABLE_STRING, XML_PACKAGE_NAMESPACE_VAR_NAME, Modifier.FINAL, Modifier.STATIC, Modifier.PRIVATE)
+                            .initializer("$S", namespace)
                             .build()
                     ),
                     () -> xmlStaticClass.addField(
-                        FieldSpec.builder(OPTIONAL_STRING, XML_PACKAGE_NAMESPACE_VAR_NAME, Modifier.FINAL, Modifier.STATIC, Modifier.PRIVATE)
-                            .initializer("$T.empty()", OPTIONAL)
+                        FieldSpec.builder(NULLABLE_STRING, XML_PACKAGE_NAMESPACE_VAR_NAME, Modifier.FINAL, Modifier.STATIC, Modifier.PRIVATE)
+                            .initializer("null")
                             .build()
                     )
                 );
@@ -132,21 +127,10 @@ public final class WriteStaticToXml extends ToXmlMethod {
                     .addJavadoc("The incoming tag that was requested")
                     .build()
             )
-            .addStatement(
-                """
-                    return $T.ofNullable(incomingTag)
-                        .filter($T::nonNull)
-                        .filter($T.not($T::isBlank))
-                        .filter(x -> !$T.XML_DEFAULT_STRING.equals(x))
-                        .orElse($L)
-                """.trim(),
-                OPTIONAL, 
-                OBJECTS, 
-                PREDICATE,
-                STRING,
-                ARU_GENERATED,
-                XML_DEFAULT_TAG_NAME_VAR_NAME
-            );
+            .beginControlFlow("if (incomingTag != null && (!incomingTag.isBlank()) && (!$T.XML_DEFAULT_STRING.equals(incomingTag)))", ARU_GENERATED)
+            .addStatement("return incomingTag")
+            .endControlFlow()
+            .addStatement("return $L", XML_DEFAULT_TAG_NAME_VAR_NAME);
         AnnotationSupplier.addGeneratedAnnotation(methodBuilder, this);
     }
 
@@ -163,7 +147,7 @@ public final class WriteStaticToXml extends ToXmlMethod {
         AnnotationSupplier.addGeneratedAnnotation(methodBuilder, this);
         methodBuilder.modifiers.clear();
         methodBuilder.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-            .returns(OPTIONAL_STRING)
+            .returns(NULLABLE_STRING)
             .addJavadoc("Determine the final namespace of the current XmlRootElement")
             .addParameter(
                 REQ_NS_PARAM
@@ -171,34 +155,14 @@ public final class WriteStaticToXml extends ToXmlMethod {
             .addParameter(
                 CURR_DEF_NS_PARAM
             )
-            .addStatement(
-                """
-                return $T.ofNullable(requestedNamespace)
-                    .filter($T::nonNull)
-                    .filter($T.not($T::isBlank))
-                    .filter(x -> !$T.XML_DEFAULT_STRING.equals(x))
-                    .or(() -> $L)
-                    .or(
-                        () -> $T.ofNullable(currentDefaultNamespace)
-                            .filter($T::nonNull)
-                            .filter($T.not($T::isBlank))
-                            .filter(x -> !$T.XML_DEFAULT_STRING.equals(x))
-                    )
-                    .or(() -> $L)
-                """.trim(),
-                OPTIONAL,
-                OBJECTS, 
-                PREDICATE,
-                STRING,
-                ARU_GENERATED,
-                XML_DEFAULT_NAMESPACE_VAR_NAME,
-                OPTIONAL,
-                OBJECTS, 
-                PREDICATE,
-                STRING,
-                ARU_GENERATED,
-                XML_PACKAGE_NAMESPACE_VAR_NAME
-            );
+            .beginControlFlow("if (requestedNamespace != null && (!requestedNamespace.isBlank()) && (!$T.XML_DEFAULT_STRING.equals(requestedNamespace)))", ARU_GENERATED)
+            .addStatement("return requestedNamespace")
+            .nextControlFlow("else if ($L != null)", XML_DEFAULT_NAMESPACE_VAR_NAME)
+            .addStatement("return $L", XML_DEFAULT_NAMESPACE_VAR_NAME)
+            .nextControlFlow("else if (currentDefaultNamespace != null && (!currentDefaultNamespace.isBlank()) && (!$T.XML_DEFAULT_STRING.equals(currentDefaultNamespace)))", ARU_GENERATED)
+            .addStatement("return currentDefaultNamespace")
+            .endControlFlow()
+            .addStatement("return $L", XML_PACKAGE_NAMESPACE_VAR_NAME);
     }
 
     private void writeCreateNamespaceNonRoot() {
@@ -206,7 +170,7 @@ public final class WriteStaticToXml extends ToXmlMethod {
         AnnotationSupplier.addGeneratedAnnotation(methodBuilder, this);
         methodBuilder.modifiers.clear();
         methodBuilder.addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-            .returns(OPTIONAL_STRING)
+            .returns(NULLABLE_STRING)
             .addJavadoc("Determine the final namespace of the current XmlType")
             .addParameter(
                 REQ_NS_PARAM
@@ -214,80 +178,35 @@ public final class WriteStaticToXml extends ToXmlMethod {
             .addParameter(
                 CURR_DEF_NS_PARAM
             )
-            .addStatement(
-                """
-                return $T.ofNullable(requestedNamespace)
-                    .filter($T::nonNull)
-                    .filter($T.not($T::isBlank))
-                    .filter(x -> !$T.XML_DEFAULT_STRING.equals(x))
-                    .or(() -> $L)
-                    .or(
-                        () -> $T.ofNullable(currentDefaultNamespace)
-                            .filter($T::nonNull)
-                            .filter($T.not($T::isBlank))
-                            .filter(x -> !$T.XML_DEFAULT_STRING.equals(x))
-                    )
-                """.trim(),
-                OPTIONAL,
-                OBJECTS, 
-                PREDICATE,
-                STRING,
-                ARU_GENERATED,
-                XML_DEFAULT_NAMESPACE_VAR_NAME,
-                OPTIONAL,
-                OBJECTS, 
-                PREDICATE,
-                STRING,
-                ARU_GENERATED
-            );
-    }
-
-    private void writeChangeDefaultNamespace(final MethodSpec.Builder methodBuilder) {
-        final ClassName xmlUtilCn = xmlStaticClass.className();
-        if (xmlRootElementPrism.isPresent()) {
-            methodBuilder.beginControlFlow("if ($T.$L.isPresent()) ", xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME)
-            .addStatement(
-                "output.setDefaultNamespace($T.$L.get())", xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME
-            )
+            .beginControlFlow("if (requestedNamespace != null && (!requestedNamespace.isBlank()) && (!$T.XML_DEFAULT_STRING.equals(requestedNamespace)))", ARU_GENERATED)
+            .addStatement("return requestedNamespace")
+            .nextControlFlow("else if ($L != null)", XML_DEFAULT_NAMESPACE_VAR_NAME)
+            .addStatement("return $L", XML_DEFAULT_NAMESPACE_VAR_NAME)
+            .nextControlFlow("else if (currentDefaultNamespace != null && (!currentDefaultNamespace.isBlank()) && (!$T.XML_DEFAULT_STRING.equals(currentDefaultNamespace)))", ARU_GENERATED)
+            .addStatement("return currentDefaultNamespace")
             .endControlFlow()
-            .addStatement(
-                "final @$T String namespaceToPassDown = $T.$L.orElse(currentDefaultNamespace)", NULLABLE, xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME
-            );
-            
-        } else {
-            methodBuilder.addStatement(
-                "final $T defNs = $T.$L.filter(ignored -> (requestedNamespace != null) && (!requestedNamespace.isBlank()))", OPTIONAL_STRING, xmlUtilCn, XML_DEFAULT_NAMESPACE_VAR_NAME
-            )
-            .beginControlFlow("if (defNs.isPresent())")
-            .addStatement(
-                "output.setDefaultNamespace(defNs.get())"
-            )
-            .endControlFlow()
-            .addStatement(
-                "final @$T String namespaceToPassDown = defNs.orElse(currentDefaultNamespace)", NULLABLE
-            );
-        }
+            .addStatement("return null");
     }
 
     private void writeSelfToExistingWithTagAndNamespace(final AnalysedRecord analysedRecord) {
         final MethodSpec.Builder methodBuilder = createMethod(analysedRecord)
             .addStatement("final $T tag = $T.$L(requestedTagName)", STRING, xmlStaticClass.className(), "createTag")
-            .addStatement("final $T namespace = $T.createNamespace(requestedNamespace, currentDefaultNamespace)", OPTIONAL_STRING, xmlStaticClass.className());
+            .addStatement("final $T namespace = $T.createNamespace(requestedNamespace, currentDefaultNamespace)", NULLABLE_STRING, xmlStaticClass.className());
         configureNamespaceContext(analysedRecord, methodBuilder);
         writeChangeDefaultNamespace(methodBuilder);
-        methodBuilder.beginControlFlow("if (namespace.isPresent())")
-                .addStatement("final $T namespaceValue = namespace.get()", STRING)
-                .addStatement("output.writeStartElement(namespaceValue, tag)")
-                .beginControlFlow("if (!$T.equals(namespaceValue, currentDefaultNamespace))", OBJECTS)
-                .addStatement("output.writeDefaultNamespace(namespaceValue)")
+        methodBuilder.beginControlFlow("if (namespace != null)")
+                .addStatement("output.writeStartElement(namespace, tag)")
+                .beginControlFlow("if (!$T.equals(namespace, currentDefaultNamespace))", OBJECTS)
+                .addStatement("output.writeDefaultNamespace(namespace)")
                 .endControlFlow()
                 .nextControlFlow("else")
                 .addStatement("output.writeStartElement(tag)")
                 .endControlFlow();
+
+        addWriteOrderComment(methodBuilder);
         // OK, now to write out all the components... attributes first, then elements, then within those in order... booooooo
         final List<String> propOrder = XmlTypePrism.getOptionalOn(analysedRecord.typeElement())
             .map(XmlTypePrism::propOrder)
-            .filter(Objects::nonNull)
             .map(props -> props.stream().filter(StringUtils::isNotBlank).toList())
             .orElse(List.of());
     
@@ -328,17 +247,17 @@ public final class WriteStaticToXml extends ToXmlMethod {
                     .build()
             )
             .addParameter(
-                ParameterSpec.builder(STRING.annotated(CommonsConstants.NULLABLE_ANNOTATION), "requestedTagName", Modifier.FINAL)
+                ParameterSpec.builder(NULLABLE_STRING, "requestedTagName", Modifier.FINAL)
                     .addJavadoc("The tag name requested for this element. If null, will use the default tag name")
                     .build()
             )
             .addParameter(
-                ParameterSpec.builder(STRING.annotated(CommonsConstants.NULLABLE_ANNOTATION), "requestedNamespace", Modifier.FINAL)
+                ParameterSpec.builder(NULLABLE_STRING, "requestedNamespace", Modifier.FINAL)
                     .addJavadoc("The namespace requested for this element. If null, will use the default namespace (NOT the one on the element)")
                     .build()
             )
             .addParameter(
-                ParameterSpec.builder(STRING.annotated(CommonsConstants.NULLABLE_ANNOTATION), "currentDefaultNamespace", Modifier.FINAL)
+                ParameterSpec.builder(NULLABLE_STRING, "currentDefaultNamespace", Modifier.FINAL)
                     .addJavadoc("The current default namespace")
                     .build()
             )

--- a/docs/generated-code/usage/xml.adoc
+++ b/docs/generated-code/usage/xml.adoc
@@ -95,14 +95,17 @@ public final class PersonUtils implements GeneratedUtil {
             Objects.requireNonNull(el, "Cannot supply null element to be written to XML");
             Objects.requireNonNull(output, "Cannot supply null output for XML content");
             final String tag = _XmlUtils.createTag(requestedTagName);
-            final Optional<String> namespace = _XmlUtils.createNamespace(requestedNamespace, currentDefaultNamespace);
-            final Optional<String> defNs = _XmlUtils.__DEFAULT_NAMESPACE_URI.filter(ignored -> Objects.nonNull(requestedNamespace) && (!requestedNamespace.isBlank()));
-            if (defNs.isPresent()) {
-                output.setDefaultNamespace(defNs.get());
+            final @Nullable String namespace = _XmlUtils.createNamespace(requestedNamespace, currentDefaultNamespace);
+            final @Nullable String defNs = (_XmlUtils.__DEFAULT_NAMESPACE_URI != null && (requestedNamespace != null) && (!requestedNamespace.isBlank())) ? _XmlUtils.__DEFAULT_NAMESPACE_URI : null;
+            if (defNs != null) {
+                output.setDefaultNamespace(defNs);
             }
-            final @Nullable String namespaceToPassDown = defNs.orElse(currentDefaultNamespace);
-            if (namespace.isPresent()) {
-                output.writeStartElement(namespace.get(), tag);
+            final @Nullable String namespaceToPassDown = defNs != null ? defNs : currentDefaultNamespace;
+            if (namespace != null) {
+                output.writeStartElement(namespace, tag);
+                if (!Objects.equals(namespace, currentDefaultNamespace)) {
+                    output.writeDefaultNamespace(namespace);
+                }
             } else {
                 output.writeStartElement(tag);
             }
@@ -144,17 +147,14 @@ public final class PersonUtils implements GeneratedUtil {
         )
         private static final Optional<String> createNamespace(@Nullable final String requestedNamespace,
                 @Nullable final String currentDefaultNamespace) {
-            return Optional.ofNullable(requestedNamespace)
-                        .filter(Objects::nonNull)
-                        .filter(Predicate.not(String::isBlank))
-                        .filter(x -> !AdvancedRecordUtilsGenerated.XML_DEFAULT_STRING.equals(x))
-                        .or(() -> __DEFAULT_NAMESPACE_URI)
-                        .or(
-                            () -> Optional.ofNullable(currentDefaultNamespace)
-                                .filter(Objects::nonNull)
-                                .filter(Predicate.not(String::isBlank))
-                                .filter(x -> !AdvancedRecordUtilsGenerated.XML_DEFAULT_STRING.equals(x))
-                        );
+            if (requestedNamespace != null && (!requestedNamespace.isBlank()) && (!AdvancedRecordUtilsGenerated.XML_DEFAULT_STRING.equals(requestedNamespace))) {
+                return requestedNamespace;
+            } else if (__DEFAULT_NAMESPACE_URI != null) {
+                return __DEFAULT_NAMESPACE_URI;
+            } else if (currentDefaultNamespace != null && (!currentDefaultNamespace.isBlank()) && (!AdvancedRecordUtilsGenerated.XML_DEFAULT_STRING.equals(currentDefaultNamespace))) {
+                return currentDefaultNamespace;
+            }
+            return null;
         }
 
         /**
@@ -167,11 +167,10 @@ public final class PersonUtils implements GeneratedUtil {
                 comments = "Related class claim: xmlStaticClassToXml"
         )
         private static final String createTag(final String incomingTag) {
-            return Optional.ofNullable(incomingTag)
-                            .filter(Objects::nonNull)
-                            .filter(Predicate.not(String::isBlank))
-                            .filter(x -> !AdvancedRecordUtilsGenerated.XML_DEFAULT_STRING.equals(x))
-                            .orElse(__DEFAULT_TAG_NAME);
+            if (incomingTag != null && (!incomingTag.isBlank()) && (!AdvancedRecordUtilsGenerated.XML_DEFAULT_STRING.equals(incomingTag))) {
+                return incomingTag;
+            }
+            return __DEFAULT_TAG_NAME;
         }
 
         /**
@@ -270,14 +269,17 @@ public final class PersonUtils implements GeneratedUtil {
                 @Nullable final String requestedNamespace, final String currentDefaultNamespace) throws XMLStreamException {
             Objects.requireNonNull(output, "Cannot supply null output for XML content");
             final String tag = _XmlUtils.createTag(requestedTagName);
-            final Optional<String> namespace = _XmlUtils.createNamespace(requestedNamespace, currentDefaultNamespace);
-            final Optional<String> defNs = _XmlUtils.__DEFAULT_NAMESPACE_URI.filter(ignored -> Objects.isNull(requestedNamespace) || (requestedNamespace.isBlank()));
-            if (defNs.isPresent()) {
-                output.setDefaultNamespace(defNs.get());
+            final @Nullable String namespace = _XmlUtils.createNamespace(requestedNamespace, currentDefaultNamespace);
+            final @Nullable String defNs = (_XmlUtils.__DEFAULT_NAMESPACE_URI != null && (requestedNamespace != null) && (!requestedNamespace.isBlank())) ? _XmlUtils.__DEFAULT_NAMESPACE_URI : null;
+            if (defNs != null) {
+                output.setDefaultNamespace(defNs);
             }
-            final @Nullable String namespaceToPassDown = defNs.orElse(currentDefaultNamespace);
-            if (namespace.isPresent()) {
-                output.writeStartElement(namespace.get(), tag);
+            final @Nullable String namespaceToPassDown = defNs != null ? defNs : currentDefaultNamespace;
+            if (namespace != null) {
+                output.writeStartElement(namespace, tag);
+                if (!Objects.equals(namespace, currentDefaultNamespace)) {
+                    output.writeDefaultNamespace(namespace);
+                }
             } else {
                 output.writeStartElement(tag);
             }


### PR DESCRIPTION
The old versions of these methods did a lot of operations with `Optional` and `Predicate::not`, both of which have overhead that isn't really needed. From profiling, the `Predicate::not` was actually really poor in terms of allocation overhead. This version still has `null` comparisons against `private static final` variables that we know are/are not null but the code to bypass that didn't look great - both in the generator and in the generated code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed element tracking and write-order selection to ensure accurate XML element output.

* **Refactor**
  * Reworked namespace handling to use nullable string flows instead of Optional-based logic, leading to clearer and more predictable default-namespace and start-element generation.
  * Simplified tag and namespace selection logic for more consistent XML output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->